### PR TITLE
fix export with multiple remotes

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -101,7 +101,13 @@ class GitClient(VcsClientBase):
                 return result_remotes
             remotes = result_remotes['output'].splitlines()
 
-            # TODO prefer original / upstream remote
+            # prefer origin and upstream remotes
+            if 'upstream' in remotes:
+                remotes.remove('upstream')
+                remotes.insert(0, 'upstream')
+            if 'origin' in remotes:
+                remotes.remove('origin')
+                remotes.insert(0, 'origin')
 
             # for each remote name check if the hash is part of the remote
             for remote in remotes:

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -5,6 +5,7 @@ except ImportError:
     from Queue import Empty, Queue
 import sys
 import threading
+import traceback
 
 
 def output_repositories(clients):
@@ -130,9 +131,11 @@ class Worker(threading.Thread):
                 }
             return method(job['command'])
         except Exception as e:
+            exc_tb = sys.exc_info()[2]
+            filename, lineno, _, _ = traceback.extract_tb(exc_tb)[-1]
             return {
                 'cmd': '%s.%s(%s)' % (job['client'].__class__.type, method_name, job['command'].__class__.command),
-                'output': "Invocation of command '%s' on client '%s' failed: %s" % (job['command'].__class__.command, job['client'].__class__.type, e),
+                'output': "Invocation of command '%s' on client '%s' failed: %s: %s (%s:%s)" % (job['command'].__class__.command, job['client'].__class__.type, type(e).__name__, e, filename, lineno),
                 'returncode': 1
             }
 


### PR DESCRIPTION
Replaces #8.

It fixes the export command when the repo has multiple remotes without requiring complex parsing of the git output.

Additionally when using `--exact` the patch will prefer `origin` / `upstream` remotes when the hash is available for them. That is a "better" behavior than picking the first available remote (in alphabetical order) containing the hash.

@jbohren @NikolausDemmel FYI