### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
+build
 deb_dist
 dist
 vcstool.egg-info
-build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 deb_dist
 dist
 vcstool.egg-info
+build

--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -41,11 +41,26 @@ class VcsClientBase(object):
         return None
 
 
-def find_executable(file_name):
+def is_executable_file(file_path):
+    return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
+
+
+def find_executable(file_name, check_for_exe=None):
+    # If not explicitly set, True for Windows, otherwise False
+    if check_for_exe is None:
+        check_for_exe = os.name == 'nt'
+    # Set to False if it already ends with .exe
+    if check_for_exe:
+        if file_name.endswith('.exe'):
+            check_for_exe = False
     for path in os.getenv('PATH').split(os.path.pathsep):
         file_path = os.path.join(path, file_name)
-        if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
+        if is_executable_file(file_path):
             return file_path
+        if check_for_exe:
+            file_path += '.exe'
+            if is_executable_file(file_path):
+                return file_path
     return None
 
 

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -166,6 +166,8 @@ def output_results(results, output_handler=output_result, hide_empty=False):
 
 
 def ansi(keyword):
+    if os.name == 'nt':
+        return ''
     codes = {
         'bluef': '\033[34m',
         'boldon': '\033[1m',

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -164,9 +164,16 @@ def output_results(results, output_handler=output_result, hide_empty=False):
     for i in idxs_in_order:
         output_handler(results[i], hide_empty=hide_empty)
 
+HAS_COLOR = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+IS_WINDOWS = os.name == 'nt'
+if HAS_COLOR and IS_WINDOWS:
+    HAS_COLOR = False
+    if os.environ.get('ConEmuANSI', None) == 'ON':
+        HAS_COLOR = True
+
 
 def ansi(keyword):
-    if os.name == 'nt':
+    if not HAS_COLOR:
         return ''
     codes = {
         'bluef': '\033[34m',


### PR DESCRIPTION
This:

- Disables color output, since escape sequences do not work on Windows.
- Change `find_executable` to consider files with `.exe`, e.g. `git.exe` for `git`.