### PR TITLE
add short option for --hide-empty

### DIFF
--- a/vcstool/commands/command.py
+++ b/vcstool/commands/command.py
@@ -23,7 +23,7 @@ def add_common_arguments(parser, skip_hide_empty=False, single_path=False, path_
     group = parser.add_argument_group('Common parameters')
     group.add_argument('--debug', action='store_true', default=False, help='Show debug messages')
     if not skip_hide_empty:
-        group.add_argument('--hide-empty', action='store_true', default=False, help='Hide repositories with empty output')
+        group.add_argument('-e','--hide-empty', action='store_true', default=False, help='Hide repositories with empty output')
     group.add_argument('--repos', action='store_true', default=False, help='List repositories which the command operates on')
     if single_path:
         path_help = path_help or 'Base path to look for repositories'

--- a/vcstool/commands/command.py
+++ b/vcstool/commands/command.py
@@ -23,7 +23,7 @@ def add_common_arguments(parser, skip_hide_empty=False, single_path=False, path_
     group = parser.add_argument_group('Common parameters')
     group.add_argument('--debug', action='store_true', default=False, help='Show debug messages')
     if not skip_hide_empty:
-        group.add_argument('-e','--hide-empty', action='store_true', default=False, help='Hide repositories with empty output')
+        group.add_argument('-s', '--hide-empty', '--skip-empty', action='store_true', default=False, help='Hide repositories with empty output')
     group.add_argument('--repos', action='store_true', default=False, help='List repositories which the command operates on')
     if single_path:
         path_help = path_help or 'Base path to look for repositories'


### PR DESCRIPTION
-h was taken by the obvious use, so this suggestion uses -e instead

I guess we could do capital-h  ( -H ) but i'm not sure what is more obvious.