### PR TITLE
Handle exporting repos with a a "rev-parse" prefixed with "remotes/"

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -71,10 +71,16 @@ class GitClient(VcsClientBase):
 
             # determine remote
             suffix = '/' + branch_name
+            prefix = 'remotes/'
             assert branch_with_remote.endswith(branch_name), \
                 "'%s' does not end with '%s'" % \
                 (branch_with_remote, branch_name)
-            remote = branch_with_remote[:-len(suffix)]
+            # check if `git rev-parse --abbrev-ref @{upstream}`
+            # returned a ref with the "remotes/" prefix
+            # e.g. remotes/<remote>/<branch>"
+            if not branch_with_remote.startswith(prefix):
+                prefix = ''
+            remote = branch_with_remote[len(prefix):-len(suffix)]
 
             # determine url of remote
             result_url = self._get_remote_url(remote)


### PR DESCRIPTION
If the command `git rev-parse --abbrev-ref @{upstream}` in a repo returns `remotes/<remote>/<branch>`, then `vcs export` will print the error: `src/mycatkinpkg: Could not determine remote url:`

This pull request adds logic to handle the `remotes/` prefix in the command above. If the prefix is not present the logic is unchanged.

