### PR TITLE
optionally consider nested repos

### DIFF
--- a/vcstool/commands/command.py
+++ b/vcstool/commands/command.py
@@ -16,6 +16,7 @@ class Command(object):
     def __init__(self, args):
         self.debug = args.debug if 'debug' in args else False
         self.hide_empty = args.hide_empty if 'hide_empty' in args else False
+        self.nested = args.nested if 'nested' in args else False
         self.output_repos = args.repos if 'repos' in args else False
         if 'paths' in args:
             self.paths = args.paths
@@ -35,7 +36,8 @@ def check_greater_zero(value):
 
 
 def add_common_arguments(
-    parser, skip_hide_empty=False, single_path=False, path_help=None
+    parser, skip_hide_empty=False, skip_nested=False, single_path=False,
+    path_help=None
 ):
     parser.formatter_class = argparse.ArgumentDefaultsHelpFormatter
     group = parser.add_argument_group('Common parameters')
@@ -46,6 +48,10 @@ def add_common_arguments(
         group.add_argument(
             '-s', '--hide-empty', '--skip-empty', action='store_true',
             default=False, help='Hide repositories with empty output')
+    if not skip_nested:
+        group.add_argument(
+            '-n', '--nested', action='store_true',
+            default=False, help='Search for nested repositories')
     try:
         default_workers = cpu_count()
     except NotImplementedError:
@@ -81,7 +87,7 @@ def simple_main(parser, command_class, args=None):
     args = parser.parse_args(args)
 
     command = command_class(args)
-    clients = find_repositories(command.paths)
+    clients = find_repositories(command.paths, nested=command.nested)
     if command.output_repos:
         output_repositories(clients)
     jobs = generate_jobs(clients, command)

--- a/vcstool/commands/custom.py
+++ b/vcstool/commands/custom.py
@@ -73,7 +73,7 @@ def main(args=None):
     command = CustomCommand(args)
 
     # filter repositories by specified client types
-    clients = find_repositories(command.paths)
+    clients = find_repositories(command.paths, nested=command.nested)
     clients = [c for c in clients if c.type in args and args.__dict__[c.type]]
 
     if command.output_repos:

--- a/vcstool/commands/export.py
+++ b/vcstool/commands/export.py
@@ -90,7 +90,7 @@ def main(args=None):
     args = parser.parse_args(args)
 
     command = ExportCommand(args)
-    clients = find_repositories(command.paths)
+    clients = find_repositories(command.paths, nested=command.nested)
     if command.output_repos:
         output_repositories(clients)
     jobs = generate_jobs(clients, command)

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -159,7 +159,7 @@ def add_dependencies(jobs):
 def main(args=None):
     parser = get_parser()
     add_common_arguments(
-        parser, skip_hide_empty=True, single_path=True,
+        parser, skip_hide_empty=True, skip_nested=True, single_path=True,
         path_help='Base path to clone repositories to')
     args = parser.parse_args(args)
     try:

--- a/vcstool/crawler.py
+++ b/vcstool/crawler.py
@@ -3,15 +3,15 @@ import os
 from . import vcstool_clients
 
 
-def find_repositories(paths):
+def find_repositories(paths, nested=False):
     repos = []
     visited = []
     for path in paths:
-        _find_repositories(path, repos, visited)
+        _find_repositories(path, repos, visited, nested=nested)
     return repos
 
 
-def _find_repositories(path, repos, visited):
+def _find_repositories(path, repos, visited, nested=False):
     abs_path = os.path.abspath(path)
     if abs_path in visited:
         return
@@ -20,16 +20,18 @@ def _find_repositories(path, repos, visited):
     client = get_vcs_client(path)
     if client:
         repos.append(client)
-    else:
-        try:
-            listdir = os.listdir(path)
-        except OSError:
-            listdir = []
-        for name in sorted(listdir):
-            subpath = os.path.join(path, name)
-            if not os.path.isdir(subpath):
-                continue
-            _find_repositories(subpath, repos, visited)
+        if not nested:
+            return
+
+    try:
+        listdir = os.listdir(path)
+    except OSError:
+        listdir = []
+    for name in sorted(listdir):
+        subpath = os.path.join(path, name)
+        if not os.path.isdir(subpath):
+            continue
+        _find_repositories(subpath, repos, visited, nested=nested)
 
 
 def get_vcs_client(path):


### PR DESCRIPTION
Fixes #57.

Since the crawling for potentially nested repos might inflict a significant overhead it is better to require an explicit option.