### PR TITLE
add import --recursive option for git submodules

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -247,7 +247,10 @@ class GitClient(VcsClientBase):
             output = result_fetch['output']
 
         else:
-            cmd_clone = [GitClient._executable, 'clone', command.url, '.']
+            cmd_clone = [GitClient._executable, 'clone']
+            if command.recursive:
+                cmd_clone.append('--recursive')
+            cmd_clone += [command.url, '.']
             result_clone = self._run_command(cmd_clone, retry=command.retry)
             if result_clone['returncode']:
                 result_clone['output'] = \

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -20,12 +20,13 @@ class ImportCommand(Command):
     command = 'import'
     help = 'Import the list of repositories'
 
-    def __init__(self, args, url, version=None):
+    def __init__(self, args, url, version=None, recursive=False):
         super(ImportCommand, self).__init__(args)
         self.url = url
         self.version = version
         self.force = args.force
         self.retry = args.retry
+        self.recursive = recursive
 
 
 def get_parser():
@@ -38,6 +39,9 @@ def get_parser():
         '--force', action='store_true', default=False,
         help='Potentially overwrite existing folders if they contain '
              'different repositories')
+    group.add_argument(
+        '--recursive', action='store_true', default=False,
+        help='Recurse into submodules')
     group.add_argument(
         '--retry', type=int, metavar='N', default=2,
         help='Retry commands requiring network access N times on failure')
@@ -136,7 +140,8 @@ def generate_jobs(repos, args):
         client = clients[0](path)
         command = ImportCommand(
             args, repo['url'],
-            str(repo['version']) if 'version' in repo else None)
+            str(repo['version']) if 'version' in repo else None,
+            recursive=args.recursive)
         job = {'client': client, 'command': command}
         jobs.append(job)
     return jobs


### PR DESCRIPTION
Only used for `git` since e.g. `hg` and `svn` seem to pull in subrepos / externals automatically.