### PR TITLE
Avoid unnecessary failure when a git repo has multiple remotes

### DIFF
--- a/test/reimport.txt
+++ b/test/reimport.txt
@@ -1,0 +1,15 @@
+.....
+=== ./immutable/hash (git) ===
+
+HEAD is now at 377d5b3... update changelog
+=== ./immutable/hash_tar (tar) ===
+Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.tar.gz' and unpacked it
+=== ./immutable/hash_zip (zip) ===
+Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
+=== ./immutable/tag (git) ===
+
+HEAD is now at bf9ca56... 0.1.27
+=== ./vcstool (git) ===
+
+Already on 'master'
+Your branch is up to date with 'origin/master'.

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -30,6 +30,19 @@ class TestCommands(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(TEST_WORKSPACE)
 
+    def test_reimport(self):
+        cwd = os.path.join(TEST_WORKSPACE, 'vcstool')
+        subprocess.check_output(
+            ['git', 'remote', 'add', 'foo', 'http://foo.com/bar.git'],
+            stderr=subprocess.STDOUT, cwd=cwd, env=dict(os.environ))
+        output = run_command(
+            'import', ['--input', REPOS_FILE, '.'])
+        expected = get_expected_output('reimport')
+        subprocess.check_output(
+            ['git', 'remote', 'remove', 'foo'],
+            stderr=subprocess.STDOUT, cwd=cwd, env=dict(os.environ))
+        assert output == expected
+
     def test_branch(self):
         output = run_command('branch')
         expected = get_expected_output('branch')

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -30,19 +30,6 @@ class TestCommands(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(TEST_WORKSPACE)
 
-    def test_reimport(self):
-        cwd = os.path.join(TEST_WORKSPACE, 'vcstool')
-        subprocess.check_output(
-            ['git', 'remote', 'add', 'foo', 'http://foo.com/bar.git'],
-            stderr=subprocess.STDOUT, cwd=cwd, env=dict(os.environ))
-        output = run_command(
-            'import', ['--input', REPOS_FILE, '.'])
-        expected = get_expected_output('reimport')
-        subprocess.check_output(
-            ['git', 'remote', 'remove', 'foo'],
-            stderr=subprocess.STDOUT, cwd=cwd, env=dict(os.environ))
-        assert output == expected
-
     def test_branch(self):
         output = run_command('branch')
         expected = get_expected_output('branch')
@@ -90,6 +77,19 @@ class TestCommands(unittest.TestCase):
             run_command('pull', args=['--workers', '1'])
         expected = get_expected_output('pull')
         self.assertEqual(e.exception.output, expected)
+
+    def test_reimport(self):
+        cwd = os.path.join(TEST_WORKSPACE, 'vcstool')
+        subprocess.check_output(
+            ['git', 'remote', 'add', 'foo', 'http://foo.com/bar.git'],
+            stderr=subprocess.STDOUT, cwd=cwd)
+        output = run_command(
+            'import', ['--input', REPOS_FILE, '.'])
+        expected = get_expected_output('reimport')
+        subprocess.check_output(
+            ['git', 'remote', 'remove', 'foo'],
+            stderr=subprocess.STDOUT, cwd=cwd)
+        self.assertEqual(output, expected)
 
     def test_remote(self):
         output = run_command('remotes', args=['--repos'])


### PR DESCRIPTION
As noted in the comment, this fixes a hard failure right now when you try to import on top of an existing repo with multiple remotes, but could be made more robust by checking off against each remote in the list instead of just the first.

Example of how it breaks right now:

```
$ vcs import src < src/delphyne_gui/delphyne.repos
=== src/delphyne (git) ===
Could not determine remote url: error: invalid key (newline): remote.origin
stonier.url
=== src/delphyne_gui (git) ===
Could not determine remote url: error: invalid key (newline): remote.origin
stonier.url
```

In those repos:

```
./src/delphyne$ git remote show
origin
stonier
```

With some extra debugging to show what is getting captured by `_get_url`:

```
$ vcs import src < src/delphyne_gui/delphyne.repos
Running command ['/usr/bin/git', 'config', '--get', u'remote.origin\nstonier.url']
Running command ['/usr/bin/git', 'config', '--get', u'remote.origin\nstonier.url']
=== src/delphyne (git) ===
Could not determine remote url: error: invalid key (newline): remote.origin
stonier.url
=== src/delphyne_gui (git) ===
Could not determine remote url: error: invalid key (newline): remote.origin
stonier.url
```
