### PR TITLE
fix usage of version with svn import

### DIFF
--- a/vcstool/clients/svn.py
+++ b/vcstool/clients/svn.py
@@ -125,7 +125,7 @@ class SvnClient(VcsClientBase):
 
         url = command.url
         if command.version:
-            url += '@%d' % command.version
+            url += '@%s' % command.version
 
         cmd_checkout = [
             SvnClient._executable, '--non-interactive', 'checkout', url, '.']


### PR DESCRIPTION
Fixes #69.

The calling code always passes a string, see https://github.com/dirk-thomas/vcstool/blob/b6d5f5f2e7be6519d23420e8f677dbdae0f58839/vcstool/commands/import_.py#L143