### PR TITLE
remove Ubuntu pre-Trusty and Debian Wheezy

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-yaml
 Depends3: python3-setuptools, python3-yaml
 Conflicts: python3-vcstool
 Conflicts3: python-vcstool
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#232 why dropping these EOL distros is necessary to allow releasing Debian packages on current Ubuntu distros.