### PR TITLE
[import] don't fail on empty repositories list, print 'warning' instead

### DIFF
--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -67,7 +67,7 @@ def get_repos_in_vcstool_format(repositories):
     repos = {}
     if repositories is None:
         print(
-            ansi('yellowf') + "List of repositories is empty" + ansi('reset'),
+            ansi('yellowf') + 'List of repositories is empty' + ansi('reset'),
             file=sys.stderr)
         return repos
     for path in repositories:

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -65,6 +65,11 @@ def get_repositories(yaml_file):
 
 def get_repos_in_vcstool_format(repositories):
     repos = {}
+    if repositories is None:
+        print(
+            ansi('yellowf') + "List of repositories is empty" + ansi('reset'),
+            file=sys.stderr)
+        return repos
     for path in repositories:
         repo = {}
         attributes = repositories[path]


### PR DESCRIPTION
required for https://github.com/ros-infrastructure/ros_buildfarm/pull/574