### PR TITLE
Support export of refs that are only part of tags

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -134,7 +134,8 @@ class GitClient(VcsClientBase):
             for remote in remotes:
                 # get all remote names
                 cmd_refs = [
-                    GitClient._executable, 'rev-list', '--remotes=' + remote]
+                    GitClient._executable, 'rev-list', '--remotes=' + remote,
+                    '--tags']
                 result_refs = self._run_command(cmd_refs)
                 if result_refs['returncode']:
                     result_refs['output'] = \


### PR DESCRIPTION
As it stands, if `vcs export` is attempted on a repository that is targeting a ref that is tagged but is not part of any branches, an error will occur:

```
<REPO>: Could not determine remote containing '<REF>'
```