### PR TITLE
flake8: use --extend-ignore to use defaults

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -12,7 +12,7 @@ log.level = logging.INFO
 def test_flake8():
     configure_logging(1)
     argv = [
-        '--ignore=' + ','.join([
+        '--extend-ignore=' + ','.join([
             'A003', 'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107']),
         '--exclude', 'vcstool/compat/shutil.py',
         '--import-order-style=google']


### PR DESCRIPTION
Otherwise new warnings which are by default ignore won't be ignored when a custom set is passed.