### PR TITLE
remove make_notifier() call which has been removed from the flake8 API

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -43,7 +43,6 @@ def get_style_guide(argv=None):
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)
     application.make_formatter()
-    application.make_notifier()
     application.make_guide()
     application.make_file_checker_manager()
     return StyleGuide(application)


### PR DESCRIPTION
The API was removed in [flake 3.7.0](https://github.com/PyCQA/flake8/blob/59fdc5250c9166f40217172bd53a430eb666f683/docs/source/release-notes/3.7.0.rst):

> Remove broken and unused `flake8.listen` plugin type