### PR TITLE
Fix argparse requirement for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from vcstool import __version__
 
 install_requires = ['PyYAML', 'setuptools']
-if sys.version_info[0] == 2:
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     install_requires.append('argparse')
 
 setup(


### PR DESCRIPTION
argparse is part of the standard library since Python 2.7

This was discovered when a stray argparse dependency showed up during RPM packaging when the dependencies were extracted from the package.