### PR TITLE
use yaml.safe_load

### DIFF
--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -51,7 +51,7 @@ def get_parser():
 
 def get_repositories(yaml_file):
     try:
-        root = yaml.load(yaml_file)
+        root = yaml.safe_load(yaml_file)
     except yaml.YAMLError as e:
         raise RuntimeError('Input data is not valid yaml format: %s' % e)
 


### PR DESCRIPTION
To avoid the following warning with newer `yaml` versions (which also fails CI):

> YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.