### PR TITLE
Set path_nargs to ? for simple_main.

### DIFF
--- a/vcstool/commands/command.py
+++ b/vcstool/commands/command.py
@@ -83,7 +83,7 @@ def existing_dir(path):
 
 
 def simple_main(parser, command_class, args=None):
-    add_common_arguments(parser)
+    add_common_arguments(parser, path_nargs='?')
     args = parser.parse_args(args)
 
     command = command_class(args)


### PR DESCRIPTION
This ensures that the commands the rely on simple_main (like
log) continue to get the old behavior of a single list of
paths (not a list of list of paths).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>