### PR TITLE
fix regressions with path/paths arguments

### DIFF
--- a/test/list2.repos
+++ b/test/list2.repos
@@ -13,5 +13,5 @@ repositories:
     version: icedtea-3.0.0
   svn/rev:
     type: svn
-    url: http://svn.red-bean.com/repos/test
+    url: https://github.com/dirk-thomas/vcstool
     version: 3

--- a/test/validate2.txt
+++ b/test/validate2.txt
@@ -6,4 +6,4 @@ Found hg repository 'http://icedtea.classpath.org/hg/icedtea8' with changeset '9
 === hg/tag (hg) ===
 Found hg repository 'http://icedtea.classpath.org/hg/icedtea8' with changeset 'icedtea-3.0.0'
 === svn/rev (svn) ===
-Found svn repository 'http://svn.red-bean.com/repos/test' with revision '3'
+Found svn repository 'https://github.com/dirk-thomas/vcstool' with revision '3'

--- a/vcstool/clients/hg.py
+++ b/vcstool/clients/hg.py
@@ -274,7 +274,7 @@ class HgClient(VcsClientBase):
                 retry=command.retry)
             if result_id_ver['returncode']:
                 result_id_ver['output'] = \
-                    "Specified version not found on remote repository " + \
+                    'Specified version not found on remote repository ' + \
                     "'%s':'%s' : %s" % \
                     (command.url, command.version, result_id_ver['output'])
                 return result_id_ver

--- a/vcstool/clients/svn.py
+++ b/vcstool/clients/svn.py
@@ -233,14 +233,14 @@ class SvnClient(VcsClientBase):
         if command.version:
             cmd_info_ver = [
                 SvnClient._executable, 'info',
-                command.url + "@" + command.version]
+                command.url + '@' + command.version]
             result_info_ver = self._run_command(
                 cmd_info_ver,
                 retry=command.retry)
 
             if result_info_ver['returncode']:
                 result_info_ver['output'] = \
-                    "Specified version not found on remote repository" + \
+                    'Specified version not found on remote repository' + \
                     "'%s':'%s' : %s" % (command.url, result_info_ver['output'])
                 return result_info_ver
 

--- a/vcstool/commands/command.py
+++ b/vcstool/commands/command.py
@@ -62,14 +62,15 @@ def add_common_arguments(
     group.add_argument(
         '--repos', action='store_true', default=False,
         help='List repositories which the command operates on')
-    if path_nargs is not False:
-        if path_help is None:
-            if path_nargs == '?':
-                path_help = 'Base path to look for repositories'
-            elif path_nargs == '*':
-                path_help = 'Base paths to look for repositories'
+    if path_nargs == '?':
+        path_help = path_help or 'Base path to look for repositories'
         group.add_argument(
             'path', nargs=path_nargs, type=existing_dir, default=os.curdir,
+            help=path_help)
+    elif path_nargs == '*':
+        path_help = path_help or 'Base paths to look for repositories'
+        group.add_argument(
+            'paths', nargs=path_nargs, type=existing_dir, default=[os.curdir],
             help=path_help)
 
 


### PR DESCRIPTION
Replaces #95.

Fixes regression introduced in https://github.com/dirk-thomas/vcstool/pull/90/files#diff-ab1fa1c2a07801d2a7ab588a990f0879L72

Instead of adding the argument `path` or `paths` with its string or list of strings default value the patch introducing the regression always added a `path` argument.