### PR TITLE
import `--force` should overwrite non-empty directories

### DIFF
--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -159,6 +159,21 @@ class TestCommands(unittest.TestCase):
             ['git', 'remote', 'remove', 'foo'],
             stderr=subprocess.STDOUT, cwd=cwd_vcstool)
 
+    def test_import_force_non_empty(self):
+        workdir = os.path.join(TEST_WORKSPACE, 'force-non-empty')
+        os.makedirs(os.path.join(workdir, './vcstool/not-a-git-repo'))
+        try:
+            output = run_command(
+                'import', ['--force', '--input', REPOS_FILE, '.'],
+                subfolder='force-non-empty')
+            expected = get_expected_output('import')
+            # newer git versions don't append ... after the commit hash
+            assert (
+                output == expected or
+                output == expected.replace(b'... ', b' '))
+        finally:
+            shutil.rmtree(workdir)
+
     def test_validate(self):
         output = run_command(
             'validate', ['--input', REPOS_FILE])

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -161,7 +161,7 @@ class TestCommands(unittest.TestCase):
 
     def test_import_force_non_empty(self):
         workdir = os.path.join(TEST_WORKSPACE, 'force-non-empty')
-        os.makedirs(os.path.join(workdir, './vcstool/not-a-git-repo'))
+        os.makedirs(os.path.join(workdir, 'vcstool', 'not-a-git-repo'))
         try:
             output = run_command(
                 'import', ['--force', '--input', REPOS_FILE, '.'],

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -238,6 +238,12 @@ class GitClient(VcsClientBase):
                     shutil.rmtree(self.path)
                 except OSError:
                     os.remove(self.path)
+        elif command.force and os.path.exists(self.path):
+            # Not empty, not a git repository
+            try:
+                shutil.rmtree(self.path)
+            except OSError:
+                os.remove(self.path)
 
         not_exist = self._create_path()
         if not_exist:

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -39,8 +39,7 @@ def get_parser():
         '--input', type=argparse.FileType('r'), default=sys.stdin)
     group.add_argument(
         '--force', action='store_true', default=False,
-        help='Potentially overwrite existing folders if they contain '
-             'different repositories')
+        help='Potentially overwrite or delete any content in existing folders')
     group.add_argument(
         '--recursive', action='store_true', default=False,
         help='Recurse into submodules')

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -39,7 +39,8 @@ def get_parser():
         '--input', type=argparse.FileType('r'), default=sys.stdin)
     group.add_argument(
         '--force', action='store_true', default=False,
-        help='Potentially overwrite or delete any content in existing folders')
+        help="Delete existing directories if they don't contain the"
+            " repository being imported")
     group.add_argument(
         '--recursive', action='store_true', default=False,
         help='Recurse into submodules')

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -40,7 +40,7 @@ def get_parser():
     group.add_argument(
         '--force', action='store_true', default=False,
         help="Delete existing directories if they don't contain the"
-            " repository being imported")
+             " repository being imported")
     group.add_argument(
         '--recursive', action='store_true', default=False,
         help='Recurse into submodules')

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -39,8 +39,8 @@ def get_parser():
         '--input', type=argparse.FileType('r'), default=sys.stdin)
     group.add_argument(
         '--force', action='store_true', default=False,
-        help="Delete existing directories if they don't contain the"
-             " repository being imported")
+        help="Delete existing directories if they don't contain the "
+             'repository being imported')
     group.add_argument(
         '--recursive', action='store_true', default=False,
         help='Recurse into submodules')


### PR DESCRIPTION
This makes `import --force` overwrite directories, even if they're not empty and not a git repository. I have only tested this with `git`. I haven't checked the other clients, so I don't know if they're also affected.