### PR TITLE
Add cosmic, disco, and eoan suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-setuptools, python-yaml
 Depends3: python3-setuptools, python3-yaml
 Conflicts: python3-vcstool
 Conflicts3: python-vcstool
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.