### PR TITLE
Fix output on failed checkout

### DIFF
--- a/vcstool/clients/hg.py
+++ b/vcstool/clients/hg.py
@@ -166,7 +166,7 @@ class HgClient(VcsClientBase):
             if result_checkout['returncode']:
                 result_checkout['output'] = \
                     "Could not checkout '%s': %s" % \
-                    (command.version, result_clone['output'])
+                    (command.version, result_checkout['output'])
                 return result_checkout
             cmd += ' && ' + ' '.join(cmd_checkout)
             output = '\n'.join([output, result_checkout['output']])


### PR DESCRIPTION
Without this fix, a failed checkout will print a vcstool internal error:

```
=== src/ign-common (hg) ===
Invocation of command 'import' on client 'hg' failed: UnboundLocalError: local variable 'result_clone' refer
enced before assignment (/usr/local/lib/python3.6/dist-packages/vcstool/clients/hg.py:169) 
```

With the fix, we get the desired message, in my case:

```
=== src/ign-common (hg) ===
Could not checkout 'custom_paths_uri': abort: uncommitted changes
(commit or update --clean to discard changes)
```