### PR TITLE
pin PyYAML version for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - python: 3.7
     - python: 3.8
 install:
+  # newer versions of PyYAML dropped support for Python 3.4
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install coverage flake8 flake8-docstrings flake8-import-order pytest PyYAML
 script:
   - PYTHONPATH=`pwd` pytest -s -v test


### PR DESCRIPTION
PyYAML 5.3+ only supports Python 3.5+.