### PR TITLE
Update key fingerprint in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ On Debian-based platforms the recommended method is to install the package *pyth
 On Ubuntu this is done using *apt-get*::
 
   sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+  sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xAB17C654
   sudo apt-get update
   sudo apt-get install python3-vcstool
 


### PR DESCRIPTION
I had to update the key fingerprint because the ROS repo uses a different one:

```
Hit:1 https://download.docker.com/linux/debian buster InRelease
Hit:2 https://nvidia.github.io/libnvidia-container/debian10/amd64  InRelease                                                                                                     
Hit:3 https://nvidia.github.io/nvidia-container-runtime/debian10/amd64  InRelease                                                                                                
Hit:4 http://security.debian.org/debian-security buster/updates InRelease                                                                                                        
Hit:5 https://nvidia.github.io/nvidia-docker/debian10/amd64  InRelease                                                                                                           
Get:6 http://packages.microsoft.com/repos/vscode stable InRelease [3,959 B]                                                                                                      
Hit:7 https://deb.debian.org/debian buster InRelease                                                                                                                             
Hit:8 https://deb.debian.org/debian buster-updates InRelease                                                                                                                    
Hit:9 https://deb.debian.org/debian buster-backports InRelease                                                                                
Get:10 http://packages.ros.org/ros/ubuntu buster InRelease [4,633 B]                                                                          
Hit:11 https://apt.spideroak.com/ubuntu release InRelease                                                                             
Hit:12 https://packagecloud.io/github/git-lfs/debian buster InRelease
Err:10 http://packages.ros.org/ros/ubuntu buster InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654
Reading package lists... Done
W: GPG error: http://packages.ros.org/ros/ubuntu buster InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654
E: The repository 'http://packages.ros.org/ros/ubuntu buster InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```