### PR TITLE
add log --verbose option

### DIFF
--- a/test/log_limit.txt
+++ b/test/log_limit.txt
@@ -2,27 +2,21 @@
 === ./hash (git) ===
 commit 377d5b3d03c212f015cc832fdb368f4534d0d583
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
-Date:   Wed May 31 09:56:38 2017 -0700
 
     update changelog
 
 commit f01ce3845fa0783bef9f97545e518e0f02cd509a
 Merge: 14f9968 e7770d3
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
-Date:   Wed May 31 09:55:04 2017 -0700
 
     Merge pull request #44 from dirk-thomas/fix_loop_exit
-    
-    fix exit condition in loop
 === ./tag (git) ===
 commit bf9ca56de693a02b93ed423bcef589259d75eb0f
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
-Date:   Wed May 31 09:57:59 2017 -0700
 
     0.1.27
 
 commit 377d5b3d03c212f015cc832fdb368f4534d0d583
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
-Date:   Wed May 31 09:56:38 2017 -0700
 
     update changelog

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -385,6 +385,8 @@ class GitClient(VcsClientBase):
             cmd = [GitClient._executable, 'log']
         if command.limit != 0:
             cmd += ['-%d' % command.limit]
+        if not command.verbose:
+            cmd += ['--pretty=short']
         self._check_color(cmd)
         return self._run_command(cmd)
 

--- a/vcstool/clients/hg.py
+++ b/vcstool/clients/hg.py
@@ -215,6 +215,8 @@ class HgClient(VcsClientBase):
             cmd = [HgClient._executable, 'log']
         if command.limit != 0:
             cmd += ['--limit', '%d' % command.limit]
+        if command.verbose:
+            cmd += ['--verbose']
         self._check_color(cmd)
         return self._run_command(cmd)
 

--- a/vcstool/commands/log.py
+++ b/vcstool/commands/log.py
@@ -17,6 +17,7 @@ class LogCommand(Command):
         self.limit = args.limit
         self.limit_tag = args.limit_tag
         self.limit_untagged = args.limit_untagged
+        self.verbose = args.verbose
 
 
 def get_parser():
@@ -33,6 +34,9 @@ def get_parser():
     ex_group.add_argument(
         '--limit-untagged', action='store_true', default=False,
         help='Limit number of log to the last tagged commit')
+    group.add_argument(
+        '--verbose', action='store_true', default=False,
+        help='Show the full commit message')
     return parser
 
 


### PR DESCRIPTION
This changes the default for `git` to `--pretty=short` which still shows the commit hash, author, (merge), and title but not the date and the full commit message anymore.

For `hg` is doesn't change the default but `--verbose` allows showing the list of changed files and the full commit message.