### PR TITLE
Fix encoding issue when running command on non-UTF8 system

### DIFF
--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -79,12 +79,12 @@ def run_command(cmd, cwd, env=None):
     try:
         proc = subprocess.Popen(
             cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            env=env)
+            env=env, universal_newlines=True)
         output, _ = proc.communicate()
-        result['output'] = output.rstrip().decode('utf8')
+        result['output'] = output.rstrip()
         result['returncode'] = proc.returncode
     except subprocess.CalledProcessError as e:
-        result['output'] = e.output.decode('utf8')
+        result['output'] = e.output
         result['returncode'] = e.returncode
     return result
 


### PR DESCRIPTION
On Windows platform configured with non-english locale, the date displayed by `svn info` is in the locale format even if the rest of the svn output is in english.
The date can then contain accentuated characters or special punctuation and doesn't convert well since the encoding is not UTF-8 on this platform.

With this fix, *vcstool* won't assume the process will be run with UTF-8 encoding but let Python libs determine the right encoding.
`universal_newlines` argument is used instead of `text` to support more Python versions (`text` requires Python 3.7).