### PR TITLE
Allow fetching repos from url

### DIFF
--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Rover Robotics c/o Dan Rose
+# Licensed under the Apache License, Version 2.0
+import base64
+
+from vcstool.commands import import_
+from urllib.parse import urlencode
+
+REPOS_YAML = """
+repositories:
+  vcstool:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: master
+"""
+
+
+def test_import_file(tmp_path):
+    repos_file = tmp_path / 'repos.yml'
+    repos_file.write_text(REPOS_YAML)
+    import_.main(args=[str(tmp_path), '--input', str(repos_file)])
+    assert (tmp_path / 'vcstool'/'.git').is_dir()
+
+
+def test_import_file_url(tmp_path):
+    repos_file = tmp_path / 'repos.yml'
+    repos_file.write_text(REPOS_YAML)
+    repos_url = 'file:/' + str(repos_file)
+    import_.main(args=[str(tmp_path), '--input', str(repos_url)])
+    assert (tmp_path / 'vcstool'/'.git').is_dir()
+
+
+REPOS_DATA_URL = (
+    "data:text/x-yaml;charset=utf-8,"
+    "repositories%3A%0D%0A%20%20vcstool%3A%0D%0A%20%20%20%20type%3A"
+    "%20git%0D%0A%20%20%20%20url%3A%20https%3A%2F%2Fgithub.com%2Fdirk-thomas"
+    "%2Fvcstool.git%0D%0A%20%20%20%20version%3A%20master"
+)
+
+def test_import_data_url(tmp_path):
+    data_url = b'data:text/x-yaml;base64,'+base64.b64encode(REPOS_YAML)
+    import_.main(args=[tmp_path, '--input', data_url])
+    assert (tmp_path / 'vcstool'/'.git').is_dir()

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import argparse
 import os
 import sys
+import urllib.request
 
 from vcstool.clients import vcstool_clients
 from vcstool.clients.vcs_base import run_command
@@ -33,12 +34,20 @@ class ImportCommand(Command):
         self.recursive = recursive
 
 
+def file_or_url_type(x):
+    try:
+        return urllib.request.urlopen(x)
+    except ValueError:
+        return argparse.FileType('r')(x)
+
+
 def get_parser():
     parser = argparse.ArgumentParser(
         description='Import the list of repositories', prog='vcs import')
     group = parser.add_argument_group('"import" command parameters')
     group.add_argument(
-        '--input', type=argparse.FileType('r'), default=sys.stdin)
+        '--input', type=file_or_url_type, default='-',
+        help="Where to read YAML from.", metavar='FILE_OR_URL')
     group.add_argument(
         '--force', action='store_true', default=False,
         help="Delete existing directories if they don't contain the "

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import argparse
 import os
 import sys
-import urllib.request
 
 from vcstool.clients import vcstool_clients
 from vcstool.clients.vcs_base import run_command
@@ -14,6 +13,11 @@ from vcstool.executor import output_repositories
 from vcstool.executor import output_results
 from vcstool.streams import set_streams
 import yaml
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 from .command import add_common_arguments
 from .command import Command
@@ -36,7 +40,7 @@ class ImportCommand(Command):
 
 def file_or_url_type(x):
     try:
-        return urllib.request.urlopen(x)
+        return urlopen(x)
     except ValueError:
         return argparse.FileType('r')(x)
 


### PR DESCRIPTION
If a URL is passed to --input, we fetch the resource. This removes the need for curl or wget in many cases.