### PR TITLE
Fix crashes due to catching AttributeError instead of KeyError

### DIFF
--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -65,7 +65,7 @@ def get_repositories(yaml_file):
     try:
         repositories = root['repositories']
         return get_repos_in_vcstool_format(repositories)
-    except AttributeError as e:
+    except KeyError as e:
         raise RuntimeError('Input data is not valid format: %s' % e)
     except TypeError as e:
         # try rosinstall file format
@@ -90,7 +90,7 @@ def get_repos_in_vcstool_format(repositories):
             repo['url'] = attributes['url']
             if 'version' in attributes:
                 repo['version'] = attributes['version']
-        except AttributeError as e:
+        except KeyError as e:
             print(
                 ansi('yellowf') + (
                     "Repository '%s' does not provide the necessary "
@@ -110,7 +110,7 @@ def get_repos_in_rosinstall_format(root):
         attributes = list(item.values())[0]
         try:
             path = attributes['local-name']
-        except AttributeError as e:
+        except KeyError as e:
             print(
                 ansi('yellowf') + (
                     'Repository #%d does not provide the necessary '
@@ -121,7 +121,7 @@ def get_repos_in_rosinstall_format(root):
             repo['url'] = attributes['uri']
             if 'version' in attributes:
                 repo['version'] = attributes['version']
-        except AttributeError as e:
+        except KeyError as e:
             print(
                 ansi('yellowf') + (
                     "Repository '%s' does not provide the necessary "


### PR DESCRIPTION
e.g.
```
echo 'repositories: {somedir: {type: git}}' | vcs import .
Traceback (most recent call last):
  File "/home/dan/.local/bin/vcs", line 11, in <module>
    load_entry_point('vcstool', 'console_scripts', 'vcs')()
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/vcs.py", line 26, in main
    return entrypoint(args)
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/import_.py", line 186, in main
    repos = get_repositories(args.input)
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/import_.py", line 67, in get_repositories
    return get_repos_in_vcstool_format(repositories)
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/import_.py", line 90, in get_repos_in_vcstool_format
    repo['url'] = attributes['url']
KeyError: 'url'
```

versus
```
echo 'repositories: {somedir: {type: git}}' | vcs import .
Repository 'somedir' does not provide the necessary information:
```
