### PR TITLE
Fix unsupported repo type crash

### DIFF
--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -200,6 +200,8 @@ def main(args=None, stdout=None, stderr=None):
         ssh_keygen = None
         checked_hosts = set()
         for job in list(jobs):
+            if job['command'] is None:
+                continue
             url = job['command'].url
             # only check the host from a ssh URL
             if not url.startswith('git@') or ':' not in url:


### PR DESCRIPTION
previously:
```
echo 'repositories: {somedir: {type: foo, url: aoeu}}' | vcs import .
Traceback (most recent call last):
  File "/home/dan/.local/bin/vcs", line 11, in <module>
    load_entry_point('vcstool', 'console_scripts', 'vcs')()
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/vcs.py", line 26, in main
    return entrypoint(args)
  File "/home/dan/Documents/colcon/src/vcstool/vcstool/commands/import_.py", line 203, in main
    url = job['command'].url
AttributeError: 'NoneType' object has no attribute 'url'
```

now:
```
echo 'repositories: {somedir: {type: foo, url: aoeu}}' | vcs import .
=== ./somedir (none) ===
Repository type 'foo' is not supported
```
