### PR TITLE
Fix crash under Windows when files are readonly

### DIFF
--- a/vcstool/clients/bzr.py
+++ b/vcstool/clients/bzr.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import shutil
 
 from .vcs_base import VcsClientBase
 from .vcs_base import which
@@ -63,14 +62,17 @@ class BzrClient(VcsClientBase):
                             'repository',
                         'returncode': 1
                     }
-                try:
-                    shutil.rmtree(self.path)
-                except OSError:
-                    os.remove(self.path)
-
-        not_exist = self._create_path()
-        if not_exist:
-            return not_exist
+                fail = self._create_or_truncate_path()
+                if fail:
+                    return fail
+        elif command.force:
+            fail = self._create_or_truncate_path()
+            if fail:
+                return fail
+        else:
+            not_exist = self._create_path()
+            if not_exist:
+                return not_exist
 
         if BzrClient.is_repository(self.path):
             # pull updates for existing repo

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -236,20 +236,17 @@ class GitClient(VcsClientBase):
                             'repository',
                         'returncode': 1
                     }
-                try:
-                    shutil.rmtree(self.path)
-                except OSError:
-                    os.remove(self.path)
-        elif command.force and os.path.exists(self.path):
-            # Not empty, not a git repository
-            try:
-                shutil.rmtree(self.path)
-            except OSError:
-                os.remove(self.path)
-
-        not_exist = self._create_path()
-        if not_exist:
-            return not_exist
+                fail = self._create_or_truncate_path()
+                if fail:
+                    return fail
+        elif command.force:
+            fail = self._create_or_truncate_path()
+            if fail:
+                return fail
+        else:
+            not_exist = self._create_path()
+            if not_exist:
+                return not_exist
 
         if GitClient.is_repository(self.path):
             if command.skip_existing:

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 from vcstool.executor import USE_COLOR
 

--- a/vcstool/clients/hg.py
+++ b/vcstool/clients/hg.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from threading import Lock
 
 from vcstool.executor import USE_COLOR
@@ -126,14 +125,15 @@ class HgClient(VcsClientBase):
                             'repository',
                         'returncode': 1
                     }
-                try:
-                    shutil.rmtree(self.path)
-                except OSError:
-                    os.remove(self.path)
-
-        not_exist = self._create_path()
-        if not_exist:
-            return not_exist
+                self._create_or_truncate_path()
+        elif command.force:
+            fail = self._create_or_truncate_path()
+            if fail:
+                return fail
+        else:
+            not_exist = self._create_path()
+            if not_exist:
+                return not_exist
 
         if HgClient.is_repository(self.path):
             # pull updates for existing repo

--- a/vcstool/clients/tar.py
+++ b/vcstool/clients/tar.py
@@ -1,4 +1,3 @@
-import os
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:

--- a/vcstool/clients/tar.py
+++ b/vcstool/clients/tar.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -36,17 +35,9 @@ class TarClient(VcsClientBase):
             }
 
         # clear destination
-        if os.path.exists(self.path):
-            for filename in os.listdir(self.path):
-                path = os.path.join(self.path, filename)
-                try:
-                    shutil.rmtree(path)
-                except OSError:
-                    os.remove(path)
-        else:
-            not_exist = self._create_path()
-            if not_exist:
-                return not_exist
+        fail = self._create_or_truncate_path()
+        if fail:
+            return fail
 
         # download tarball
         try:

--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -79,11 +79,12 @@ class VcsClientBase(object):
             try:
                 os.remove(f)
             except OSError as e:
-                if getattr(e, 'winerror') != 5:
+                if getattr(e, 'winerror', None) == 5:
+                    # on Windows you need to clear the readonly bit first
+                    os.chmod(f, stat.S_IWRITE)
+                    os.remove(f)
+                else:
                     raise
-                # on Windows you need to clear the readonly bit first
-                os.chmod(f, stat.S_IWRITE)
-                os.remove(f)
 
         # If path is a symlink or a file, delete it.
         try:

--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -128,6 +128,7 @@ class VcsClientBase(object):
                             "Could not remove directory '%s': %s" % (path, e),
                         'returncode': 1
                     }
+        return None
 
 
 def run_command(cmd, cwd, env=None):

--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import socket
 import stat
@@ -88,7 +89,7 @@ class VcsClientBase(object):
         try:
             remove_file(self.path)
         except OSError as e:
-            if e.errno != 1:
+            if e.errno not in (errno.EISDIR, errno.ENOENT):
                 return {
                     'cmd': 'remove_file(%s)' % self.path,
                     'cwd': self.path,

--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -77,8 +77,8 @@ class VcsClientBase(object):
         def remove_file(f):
             try:
                 os.remove(f)
-            except WindowsError as e:
-                if e.errno != 5:
+            except OSError as e:
+                if getattr(e, 'winerror') != 5:
                     raise
                 # on Windows you need to clear the readonly bit first
                 os.chmod(f, stat.S_IWRITE)

--- a/vcstool/clients/zip.py
+++ b/vcstool/clients/zip.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
@@ -36,17 +35,9 @@ class ZipClient(VcsClientBase):
             }
 
         # clear destination
-        if os.path.exists(self.path):
-            for filename in os.listdir(self.path):
-                path = os.path.join(self.path, filename)
-                try:
-                    shutil.rmtree(path)
-                except OSError:
-                    os.remove(path)
-        else:
-            not_exist = self._create_path()
-            if not_exist:
-                return not_exist
+        fail = self._create_or_truncate_path()
+        if fail:
+            return fail
 
         # download zipfile
         try:


### PR DESCRIPTION
This frequently happens when overwriting a git repository with `vcs import --force`

Fix #130