### PR TITLE
add GitHub action workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: vcstool
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install PyYAML
+    - name: Test with pytest
+      run: |
+        pip install coverage flake8 flake8-docstrings flake8-import-order pytest
+        PYTHONPATH=`pwd` pytest -s -v test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        include:
+        - os: macos-latest
+          python-version: 3.8
+        - os: windows-latest
+          python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Using GitHub action workflow to run CI on:
* Ubuntu with all targeted Python versions
  * except 3.4 which is not supported by GitHub action, keeping Travis CI around while Debian Jessie with Python 3.4 is targeted
* macOS with the latest Python release (atm 3.8)
* Windows with the latest Python release (atm 3.8)