### PR TITLE
update expected output in tests for newer git version

### DIFF
--- a/test/import.txt
+++ b/test/import.txt
@@ -1,16 +1,22 @@
 ......
 === ./immutable/hash (git) ===
 Cloning into '.'...
-Note: checking out '377d5b3d03c212f015cc832fdb368f4534d0d583'.
+Note: switching to '377d5b3d03c212f015cc832fdb368f4534d0d583'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by performing another checkout.
+state without impacting any branches by switching back to a branch.
 
 If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -b with the checkout command again. Example:
+do so (now or later) by using -c with the switch command. Example:
 
-  git checkout -b <new-branch-name>
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at 377d5b3... update changelog
 === ./immutable/hash_tar (tar) ===
@@ -19,16 +25,22 @@ Downloaded tarball from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d
 Downloaded zipfile from 'https://github.com/dirk-thomas/vcstool/archive/377d5b3d03c212f015cc832fdb368f4534d0d583.zip' and unpacked it
 === ./immutable/tag (git) ===
 Cloning into '.'...
-Note: checking out '0.1.27'.
+Note: switching to '0.1.27'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by performing another checkout.
+state without impacting any branches by switching back to a branch.
 
 If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -b with the checkout command again. Example:
+do so (now or later) by using -c with the switch command. Example:
 
-  git checkout -b <new-branch-name>
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
 
 HEAD is now at bf9ca56... 0.1.27
 === ./vcstool (git) ===

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -255,9 +255,27 @@ def run_command(command, args=None, subfolder=None):
     cwd = TEST_WORKSPACE
     if subfolder:
         cwd = os.path.join(cwd, subfolder)
-    return subprocess.check_output(
+    output = subprocess.check_output(
         [sys.executable, script] + (args or []),
         stderr=subprocess.STDOUT, cwd=cwd, env=env)
+    # replace message from older git versions
+    # the following seems to have changed between git 2.17.1 and 2.25.1
+    output = output.replace(
+        b"Note: checking out '", b"Note: switching to '")
+    output = output.replace(
+        b'by performing another checkout.',
+        b'by switching back to a branch.')
+    output = output.replace(
+        b'using -b with the checkout command again.',
+        b'using -c with the switch command.')
+    output = output.replace(
+        b'git checkout -b <new-branch-name>',
+        b'git switch -c <new-branch-name>\n\n'
+        b'Or undo this operation with:\n\n'
+        b'  git switch -\n\n'
+        b'Turn off this advice by setting config variable '
+        b'advice.detachedHead to false')
+    return output
 
 
 def get_expected_output(name):


### PR DESCRIPTION
While still being compatible with older git versions.

Not pretty - but at least that makes the tests pass on e.g. Ubuntu Focal.