### PR TITLE
enable releasing from Focal with stdeb 0.9.1

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -5,4 +5,5 @@ Conflicts: python3-vcstool
 Conflicts3: python-vcstool
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Fixes #141.

Requires astraw/stdeb#156.