### PR TITLE
add double dash to move to another branch, not reset file/directory in git client

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -320,7 +320,7 @@ class GitClient(VcsClientBase):
 
         if checkout_version:
             cmd_checkout = [
-                GitClient._executable, 'checkout', checkout_version]
+                GitClient._executable, 'checkout', checkout_version, '--']
             result_checkout = self._run_command(cmd_checkout)
             if result_checkout['returncode']:
                 result_checkout['output'] = \


### PR DESCRIPTION
This bug occurs only when you have file and branch on remote with the same name, because if `git checkout` don't find local branch then resets file with this name.

### How to reproduce
1. Make a file `foo` and commit it
2. Make a branch `foo` and push it to remote
3. Use vcs tool with config:
```
repositories:
  repo:
    type: git
    url: git@gitlab.com:foo/bar/repo.git
    version: foo
```
4. In results, downloaded repository has branch `master` not `foo` 

### Solution
According to https://git-scm.com/docs/git-checkout adds a double dash is enough

PS. thanks to @ksuszka to found the bug!

