### PR TITLE
always --decorate git log

### DIFF
--- a/test/log_limit.txt
+++ b/test/log_limit.txt
@@ -1,6 +1,6 @@
 ..
 === ./hash (git) ===
-commit 377d5b3d03c212f015cc832fdb368f4534d0d583
+commit 377d5b3d03c212f015cc832fdb368f4534d0d583 (HEAD)
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
 
     update changelog
@@ -11,7 +11,7 @@ Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
 
     Merge pull request #44 from dirk-thomas/fix_loop_exit
 === ./tag (git) ===
-commit bf9ca56de693a02b93ed423bcef589259d75eb0f
+commit bf9ca56de693a02b93ed423bcef589259d75eb0f (HEAD, tag: 0.1.27)
 Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
 
     0.1.27

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -400,6 +400,7 @@ class GitClient(VcsClientBase):
             cmd = [GitClient._executable, 'log', '%s..' % result_tag['output']]
         else:
             cmd = [GitClient._executable, 'log']
+        cmd += ['--decorate']
         if command.limit != 0:
             cmd += ['-%d' % command.limit]
         if not command.verbose:


### PR DESCRIPTION
Before:

> commit 9de5d881774a25f37de2f8ca3fd7afc9230a1e4d

With `--decorate`:

> commit 9de5d881774a25f37de2f8ca3fd7afc9230a1e4d (HEAD -> master, origin/master, origin/HEAD)