### PR TITLE
use dash instead of stdin as default

### DIFF
--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -47,7 +47,7 @@ def get_parser():
         description='Import the list of repositories', prog='vcs import')
     group = parser.add_argument_group('"import" command parameters')
     group.add_argument(
-        '--input', type=file_or_url_type, default=sys.stdin,
+        '--input', type=file_or_url_type, default='-',
         help='Where to read YAML from', metavar='FILE_OR_URL')
     group.add_argument(
         '--force', action='store_true', default=False,

--- a/vcstool/commands/validate.py
+++ b/vcstool/commands/validate.py
@@ -31,7 +31,7 @@ def get_parser():
         description='Validate a repositories file', prog='vcs validate')
     group = parser.add_argument_group('"validate" command parameters')
     group.add_argument(
-        '--input', type=argparse.FileType('r'), default=sys.stdin)
+        '--input', type=argparse.FileType('r'), default='-')
     group.add_argument(
         '--retry', type=int, metavar='N', default=2,
         help='Retry commands requiring network access N times on failure')


### PR DESCRIPTION
Follow up of https://github.com/dirk-thomas/vcstool/pull/123#discussion_r410405443 to improve how the default values are shown in the help messages.