### PR TITLE
gracefully warn about inability to pull detached HEAD instead of fail

### DIFF
--- a/test/pull.txt
+++ b/test/pull.txt
@@ -1,4 +1,4 @@
-EE..
+....
 === ./immutable/hash (git) ===
 You are not currently on a branch.
 Please specify which branch you want to merge with.

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -152,7 +152,7 @@ invocation.
         finally:
             os.chdir(cwd_bck)
 
-        assert rc == 1
+        assert rc == 0
         # replace message from older git versions
         output = stdout_stderr.getvalue().replace(
             'anch. Please specify which\nbranch you want to merge with. See',

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -91,11 +91,10 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(output, expected)
 
     def test_pull(self):
-        with self.assertRaises(subprocess.CalledProcessError) as e:
-            run_command('pull', args=['--workers', '1'])
+        output = run_command('pull', args=['--workers', '1'])
         expected = get_expected_output('pull')
         # replace message from older git versions
-        output = e.exception.output.replace(
+        output = output.replace(
             b'anch. Please specify which\nbranch you want to merge with. See',
             b'anch.\nPlease specify which branch you want to merge with.\nSee')
         # newer git versions warn on pull with default config


### PR DESCRIPTION
Supports one use case described in #165.