### PR TITLE
[log] Clarify the behavior of --limit-*tag* options 

### DIFF
--- a/vcstool/commands/log.py
+++ b/vcstool/commands/log.py
@@ -30,10 +30,10 @@ def get_parser():
     ex_group = group.add_mutually_exclusive_group()
     ex_group.add_argument(
         '--limit-tag', metavar='TAG',
-        help='Limit number of log to the specified tag')
+        help='Limit number of log from the head to the specified tag')
     ex_group.add_argument(
         '--limit-untagged', action='store_true', default=False,
-        help='Limit number of log to the last tagged commit')
+        help='Limit number of log from the head to the last tagged commit')
     group.add_argument(
         '--verbose', action='store_true', default=False,
         help='Show the full commit message')


### PR DESCRIPTION
# Issue this change aims to resolve
As pointed out in https://github.com/dirk-thomas/vcstool/pull/173#issuecomment-713880501 and as admitted in https://github.com/dirk-thomas/vcstool/pull/173#issuecomment-713882745, the author of this PR misunderstood the expected behavior of `vcs log --limit-tag`. While help message describes the behavior correctly, wording may be a bit subtle and could signify the meaning to avoid misunderstanding.

<details><summary>Previous OP for the record</summary>

# Issue this change aims to resolve

`vcs log --limit-tag` seems to ignore the tag it receives.

Using today's `vcstool` repo, the cmd in quetion looks always returning the latest head on the current branch.
```
# vcs log --limit-tag 0.2.12
=== . (git) ===
commit ff8ce2638a17a80e3ee303db502b27e1d7dabdcf (HEAD -> master, origin/master, origin/HEAD)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>

    fix import with git older than 1.8.4.3 (#168)

commit 9c9c59a0209c97bb74af09b7a19de3104d8dae5c (tag: 0.2.14)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>

    0.2.14
:
```
Expected result:
```
# git log 0.2.12                                                            
commit 006299d1afb8e4ed74089a52f1e2af4bcd1aad41 (tag: 0.2.12)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>                                                                                                                                                         
Date:   Wed Jul 1 12:25:51 2020 -0700

    0.2.12

commit 18080f2522827c2d4dc231b317134e12bcadd7c2 (tag: 0.2.11)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
Date:   Tue Jun 16 11:14:14 2020 -0700

    0.2.11

:
```
Confirmed with:
```
# vcs --version
vcs 0.2.14
```

# Result with the fix
```
# vcs-log --verbose --limit-tag 0.2.12
=== . (git) ===
commit 006299d1afb8e4ed74089a52f1e2af4bcd1aad41 (tag: 0.2.12)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
Date:   Wed Jul 1 12:25:51 2020 -0700

    0.2.12

commit 18080f2522827c2d4dc231b317134e12bcadd7c2 (tag: 0.2.11)
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
Date:   Tue Jun 16 11:14:14 2020 -0700

    0.2.11
```
</details>