### PR TITLE
drop Python 2.7 and <= 3.4 support, Debian Jessie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ dist: xenial
 sudo: false
 matrix:
   include:
-    - python: 2.7
-    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8
 install:
-  # newer versions of PyYAML dropped support for Python 3.4
-  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install coverage flake8 flake8-docstrings flake8-import-order pytest PyYAML
 script:
   - PYTHONPATH=`pwd` pytest -s -v test

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,11 @@ Note:
   * The file format of ``vcstool export`` uses the relative paths of the repositories as keys in YAML which avoids collisions by design.
   * ``vcstool`` has significantly fewer lines of code than ``vcstools`` including the command line tools built on top.
 
+Python 2.7 / <= 3.4 support
+---------------------------
+
+The latest version supporting Python 2.7 and Python <= 3.4 is 0.2.x from the `0.2.x branch <https://github.com/dirk-thomas/vcstool/tree/0.2.x>`_.
+
 
 How does it work?
 -----------------

--- a/scripts/vcs
+++ b/scripts/vcs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-branch
+++ b/scripts/vcs-branch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-bzr
+++ b/scripts/vcs-bzr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-custom
+++ b/scripts/vcs-custom
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-diff
+++ b/scripts/vcs-diff
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-export
+++ b/scripts/vcs-export
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-git
+++ b/scripts/vcs-git
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-help
+++ b/scripts/vcs-help
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-hg
+++ b/scripts/vcs-hg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-import
+++ b/scripts/vcs-import
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-log
+++ b/scripts/vcs-log
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-pull
+++ b/scripts/vcs-pull
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-push
+++ b/scripts/vcs-push
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-remotes
+++ b/scripts/vcs-remotes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-status
+++ b/scripts/vcs-status
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-svn
+++ b/scripts/vcs-svn
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/scripts/vcs-validate
+++ b/scripts/vcs-validate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
-#!/usr/bin/env python
-
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 from vcstool import __version__
 
 install_requires = ['PyYAML', 'setuptools']
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    install_requires.append('argparse')
 
 setup(
     name='vcstool',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,9 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-setuptools, python-yaml
+No-Python2:
 Depends3: python3-setuptools, python3-yaml
-Conflicts: python3-vcstool
 Conflicts3: python-vcstool
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
-Python2-Depends-Name: python
-X-Python3-Version: >= 3.2
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+X-Python3-Version: >= 3.5


### PR DESCRIPTION
While Python 3.5 is also EOL this package continues to support it atm to continue targeting Ubuntu Xenial.

Since Debian Jessie Long Term Support has ended in June 2020 it is being removed as a targeted platform.