### PR TITLE
publish-python.yaml, future Python 3 releases to packagecloud.io and PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,12 +149,24 @@ How to install vcstool?
 =======================
 
 On Debian-based platforms the recommended method is to install the package *python3-vcstool*.
-On Ubuntu this is done using *apt-get*::
+On Ubuntu this is done using *apt-get*:
+
+If you are using `ROS <https://www.ros.org/>`_ you can get the package directly from the ROS repository::
 
   sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
   sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xAB17C654
   sudo apt-get update
   sudo apt-get install python3-vcstool
+
+If you are not using ROS or if you want the latest release as soon as possible you can get the package from |packagecloud.io|::
+
+  curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | sudo bash
+  sudo apt-get update
+  sudo apt-get install python3-vcstool
+
+.. |packagecloud.io| image:: https://img.shields.io/badge/deb-packagecloud.io-844fec.svg
+  :target: https://packagecloud.io/dirk-thomas/vcstool
+  :alt: packagecloud.io
 
 On other systems, use the `PyPI <http://pypi.python.org>`_ package::
 

--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -1,0 +1,15 @@
+artifacts:
+  - type: wheel
+    uploads:
+      - type: pypi
+  - type: stdeb
+    uploads:
+      - type: packagecloud
+        config:
+          repository: dirk-thomas/vcstool
+          distributions:
+            - ubuntu:xenial
+            - ubuntu:bionic
+            - ubuntu:focal
+            - debian:stretch
+            - debian:buster

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,5 +2,4 @@
 No-Python2:
 Depends3: python3-setuptools, python3-yaml
 Conflicts3: python-vcstool
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Add `publish-python.yaml` for future Python 3 releases to packagecloud.io and PyPI.