### PR TITLE
fix git version detection on macOS

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -21,7 +21,7 @@ class GitClient(VcsClientBase):
             output = subprocess.check_output(['git', '--version'])
             prefix = b'git version '
             assert output.startswith(prefix)
-            output = output[len(prefix):].rstrip()
+            output = output[len(prefix):].split(maxsplit=1)[0]
             cls._git_version = [
                 int(x) for x in output.split(b'.') if x != b'windows']
         return cls._git_version


### PR DESCRIPTION
Separated from #180.

The `git --version` output on macOS might look like this which wasn't supported until this patch:

> `git version 2.24.3 (Apple Git-128)`