### PR TITLE
Add fish autocompletion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,9 @@ For *zsh* append the following line to the ``~/.zshrc`` file::
 
   source /usr/share/vcstool-completion/vcs.zsh
 
+For *fish* append the following line to the ``~/.config/fishconfig.fish`` file::
+
+  source /usr/share/vcstool-completion/vcs.fish
 
 How to contribute?
 ==================

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ Currently it supports git, hg, svn and bzr.',
             'vcstool-completion/vcs.bash',
             'vcstool-completion/vcs.tcsh',
             'vcstool-completion/vcs.zsh'
+            'vcstool-completion/vcs.fish'
         ])
     ],
     entry_points={

--- a/vcstool-completion/vcs.fish
+++ b/vcstool-completion/vcs.fish
@@ -1,0 +1,6 @@
+complete -xc vcs -n '__fish_use_subcommand' -a '(vcs --commands-descriptions)'
+complete -xc vcs -s h -l help -d 'show this help message and exit'
+complete -xc vcs -l clients -d 'Show the available VCS clients'
+complete -xc vcs -l commands -d 'Output the available commands for auto-completion'
+complete -xc vcs -l commands-descriptions -d 'Output the available commands along with their descriptions for auto-completion'
+complete -xc vcs -l version -d 'Show the vcstool version'

--- a/vcstool/commands/help.py
+++ b/vcstool/commands/help.py
@@ -36,6 +36,11 @@ def main(args=None, stdout=None, stderr=None):
         print(' '.join([cmd.command for cmd in vcstool_commands]))
         return 0
 
+    if ns.commands_descriptions:
+        print('\n'.join(['{}\t{}'.format(cmd.command, cmd.help)
+                         for cmd in vcstool_commands]))
+        return 0
+
     # output detailed command list
     parser = get_parser_with_command_only()
     parser.print_help()
@@ -57,6 +62,9 @@ def get_parser(add_help=True):
     group.add_argument(
         '--commands', action='store_true', default=False,
         help='Output the available commands for auto-completion')
+    group.add_argument(
+        '--commands-descriptions', action='store_true', default=False,
+        help='Output the available commands along with their descriptions')
     from vcstool import __version__
     group.add_argument(
         '--version', action='version', version='%(prog)s ' + __version__,


### PR DESCRIPTION
Current PR adds the following:

A fish autocompletion file and the `--commands-descriptions` flag for printing the vcs subcommands in a tab-separated list along with their descriptions 
~* A small change in the README suggesting the use of `pip -e` instead of `sudo python setup.py` for installing in dev mode~
~* Minor reformatting in the flow control of the CLI parsing~

Here's how the autocompletion looks in fish now:

![1603867624-screenshot](https://user-images.githubusercontent.com/5816719/97402733-f19dda00-18ea-11eb-8b7f-84420bd0ebcf.png)
![1603867610-screenshot](https://user-images.githubusercontent.com/5816719/97402736-f2367080-18ea-11eb-88b4-9c1d5b9379a9.png)
