### PR TITLE
Don't use sudo with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,5 +210,7 @@ How to try the latest changes?
 Sourcing the ``setup.sh`` file prepends the ``src`` folder to the ``PYTHONPATH`` and the ``scripts`` folder to the ``PATH``.
 Then vcstool can be used with the commands ``vcs-COMMAND`` (note the hyphen between ``vcs`` and ``command`` instead of a space).
 
-Alternatively the *develop* command from Python setuptools can be used:
-  sudo python setup.py develop
+Alternatively the ``-e/--editable`` flag of ``pip`` can be used::
+
+  # from the top level of this repo
+  pip3 install --user -e .


### PR DESCRIPTION
Using sudo directly with `pip` is considered a bad practice in the python community, since  it's rarely actually needed, it may mess up file permissions and it can actually break `pip` if used incorrectly:

See following links for more details:

- https://github.com/pypa/pip/issues/5495
- https://askubuntu.com/a/1149202/305258


Also using sudo in this case, is unnecessary since we're operating in development mode (i.e., not copying the file contents systemwide)