### PR TITLE
always use --upgrade for pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install PyYAML
+        python -m pip install --upgrade PyYAML
     - name: Test with pytest
       run: |
-        pip install coverage flake8 flake8-docstrings flake8-import-order pytest
+        pip install --upgrade coverage flake8 flake8-docstrings flake8-import-order pytest
         PYTHONPATH=`pwd` pytest -s -v test


### PR DESCRIPTION
As recommended in https://github.com/dirk-thomas/vcstool/pull/180#issuecomment-717792626 to be on the safe side in case either of the packages is already installed.