### PR TITLE
Fixes import/export idempotency

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include vcstool-completion/vcs.bash vcstool-completion/vcs.tcsh vcstool-completi
 include vcstool-completion/vcs.fish
 include test/*.repos
 include test/*.txt
+include test/*.py

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ setup(
     name='vcstool',
     version=__version__,
     install_requires=install_requires,
-    packages=find_packages(),
+    tests_require=[
+        "pytest >= 5.0",
+        "pytest-html >= 1.19.0",
+    ],
+    packages=find_packages(exclude=["test"]),
     author='Dirk Thomas',
     author_email='web@dirk-thomas.net',
     maintainer='Dirk Thomas',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+import sys
+
+# -- SETUP PYTHON SEARCH PATH:
+HERE = Path(__file__).parent.resolve()
+TOPDIR = Path(HERE/"..").resolve()
+sys.path.insert(0, str(TOPDIR))
+
+# -- SETUP PYTHON SEARCH PATH: For subprocess(es)
+os.environ['PYTHONPATH'] = str(TOPDIR)

--- a/test/export_case1.cwd_subdir.exported.txt
+++ b/test/export_case1.cwd_subdir.exported.txt
@@ -1,0 +1,9 @@
+repositories:
+  vcstool_master:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  vcstool_tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case1.exported.txt
+++ b/test/export_case1.exported.txt
@@ -1,0 +1,9 @@
+repositories:
+  immutable/vcstool_master:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  immutable/vcstool_tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case1.imported.txt
+++ b/test/export_case1.imported.txt
@@ -1,0 +1,41 @@
+..
+=== ./immutable/vcstool_master (git) ===
+Cloning into '.'...
+Note: switching to '0.2.15'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at d120933 0.2.15
+=== ./immutable/vcstool_tag (git) ===
+Cloning into '.'...
+Note: switching to '0.1.27'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at bf9ca56 0.1.27

--- a/test/export_case1.repos
+++ b/test/export_case1.repos
@@ -1,0 +1,11 @@
+# -- FILE: export_case1.repos
+# DESCRIPTION: Multiple sub-repositories without anchor-repository.
+repositories:
+  immutable/vcstool_tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27
+  immutable/vcstool_master:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15

--- a/test/export_case1.viewpoint_subdir.exported.txt
+++ b/test/export_case1.viewpoint_subdir.exported.txt
@@ -1,0 +1,9 @@
+repositories:
+  vcstool_master:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  vcstool_tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case1.with_subdir2.exported.txt
+++ b/test/export_case1.with_subdir2.exported.txt
@@ -1,0 +1,5 @@
+repositories:
+  immutable/vcstool_tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case2.imported.txt
+++ b/test/export_case2.imported.txt
@@ -1,0 +1,41 @@
+..
+=== ./anchor (git) ===
+Cloning into '.'...
+Note: switching to '0.2.15'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at d120933 0.2.15
+=== ./anchor/immutable/tag (git) ===
+Cloning into '.'...
+Note: switching to '0.1.27'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at bf9ca56 0.1.27

--- a/test/export_case2.repos
+++ b/test/export_case2.repos
@@ -1,0 +1,12 @@
+# -- FILE: export_case2.repos (for import)
+# CASE 2A: current-directory contains anchor-repository with sub-repository(s).
+# CASE 2B: parent-directory  contains anchor-repository with sub-repository(s).
+repositories:
+  anchor:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  anchor/immutable/tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case2a.exported.txt
+++ b/test/export_case2a.exported.txt
@@ -1,0 +1,9 @@
+repositories:
+  .:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  immutable/tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case2a.with_subdir.exported.txt
+++ b/test/export_case2a.with_subdir.exported.txt
@@ -1,0 +1,5 @@
+repositories:
+  immutable/tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case2a.with_viewpoint_and_subdir.exported.txt
+++ b/test/export_case2a.with_viewpoint_and_subdir.exported.txt
@@ -1,0 +1,5 @@
+repositories:
+  tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/export_case2b.exported.txt
+++ b/test/export_case2b.exported.txt
@@ -1,0 +1,9 @@
+repositories:
+  anchor:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.2.15
+  anchor/immutable/tag:
+    type: git
+    url: https://github.com/dirk-thomas/vcstool.git
+    version: 0.1.27

--- a/test/test_command_export.py
+++ b/test/test_command_export.py
@@ -1,0 +1,524 @@
+# -*- coding_ UTF-8 -*-
+# noqa: E501
+"""
+Unit tests for the `issue #177`_ related to import/export idempotency.
+
+Import/export idempotency means:
+
+* if I use "vcs import --input=my.repos" or
+  ("vcs import some/directory --input=my.repos")
+  when I use "vcs export > my.repos2"
+  then the files "my.repos" and "my.repos2" should be the same
+  (if the vcs-repos-data-format were used for the "my.repos" file).
+
+* Therefore, you can use "vcs import ..." / "vcs export ..." cycles
+  as often as you want, the generated repos-file stay the same
+  (can be created in a reproducible way)
+  and no additional directory-tree(s) are created during additional runs.
+
+PROBLEMS WITH CURRENT EXPORTED DATA:
+
+* CASE 1: Without git-anchor-repository as current-working-directory
+
+  Normal export works (from import-directory location), but:
+
+  - "vcs export" from within a repo-directory has basename instead of ".".
+  - "vcs export --nested some/subdir" cuts prefix "some/subdir/" from repo-name
+
+  REASON: "vcs export" does not distinguish between the two concepts:
+
+  * filter (which directory-subtree is of interest) and
+  * view-point (from which directory the repository-directory names are seen)
+
+* CASE 2A: With anchor-repository as current-working-directory
+
+  DEFINITION: anchor-directory := current-working-directory (as absolute path)
+  anchor-directory is root-directory of the anchor-repository
+  (that contains ".git/")
+
+  Repo locations are prefixed w/ basename of git-anchor-repository directory.
+  Therefore, the exported repo data looks like it was exported
+  from the parent-directory of the current-working-directory
+
+  VIEW POINT: .. (parent-directory)
+  => vcs export --nested $(basename anchor-directory)
+  => vcs export --nested $(relpath_to anchor-directory)  # SAME-AS-ABOVE
+  => repos-file-data contains: "$(basename anchor-directory)/" prefix in name
+
+* CASE 2B: Some parent of anchor-repository as current-working-directory
+
+  EXAMPLE view point: anchor-directory/../ == current-working-directory
+  => vcs export --nested $(relpath_to anchor-directory)
+  => repos-file-data contains: "$(relpath_to anchor-directory)"
+     prefixes in name(s)
+
+DESIRED CHANGES:
+
+* BACKWARD COMPATIBLE (if this is desired; see impact below):
+  Current implementation state should be reproducible,
+  but by using other means, like additional CLI options.
+
+* CASE 2A: Should use relpath_to:current-working-directory instead of
+  relpath_from:parent-directory:to:current-working-directory
+
+* CASE 2B: Same as CASE 2A (with relpath_to:... instead of basename),
+  provides location(s) to repos as name(s).
+
+* CASE 1: Provides locations in exported repo-names
+  (same behaviour as in CASE 2A and CASE 2B)
+
+BACKWARD COMPATIBILITY (with additional options; reproduces current state):
+
+* CASE 1  with "vcs export --nested --view-point=subdir subdir"
+  (SAME AS: "cd subdir; vcs export --nested")
+
+* CASE 2A with "vcs export --nested --view-point=.."
+
+CLI CHANGES:
+
+* paths args: Used to filter/select which directory-subtrees are exported.
+  Cardinality: 0..N = many (was: 0..1 = optional).
+  FORMERLY: paths are used as filter and define the viewpoint.
+
+* ADDED: --view-point option, used to define the viewpoint.
+
+NEW OPTIONS (optional):
+
+* --view-point : path = "."; cardinality: 0..1 (optional)
+
+    Provides the view from which the repo-location(s) should be computed
+    with view_point_directory.relpath_to(discovered_repo_dir).
+
+    ALTERNATIVE OPTION NAME CANDIDATE: --view=..., --viewed-from=...
+
+ADDITIONAL MORE USEFUL OPTIONS (not implemented / covered here):
+
+* --exclude : path; cardinality: 0..N (optional-many)
+
+    Provides path or relpath from current-working-directory
+    that should be excluded in the exported repos-data.
+    The excluded path filters out any repository(s)
+    that is/are located in this directory or below it.
+
+.. seealso:: `issue #177`_
+
+    RELATED:
+
+    * https://github.com/dirk-thomas/vcstool/pull/102
+    * https://github.com/dirk-thomas/vcstool/issues/101
+
+.. _`issue #177`: https://github.com/dirk-thomas/vcstool/issues/177
+"""
+
+# -- HINT: Test support functionality should be refactored out into own module
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from test.test_commands import get_expected_output, run_command
+from test.workspace_util import make_imported_workspace_by_name
+
+import pytest
+
+# -----------------------------------------------------------------------------
+# CONSTANTS
+# -----------------------------------------------------------------------------
+TOPDIR = Path(__file__).parent.parent.resolve()
+PYTHON_VERSION = sys.version_info[:2]
+PY37_OR_GREATER = (PYTHON_VERSION >= (3, 7))
+
+
+# -----------------------------------------------------------------------------
+# TEST SUPPORT
+# -----------------------------------------------------------------------------
+def print_output(output):
+    if not isinstance(output, str):
+        output = output.decode(encoding='UTF-8')
+    print(output)
+
+
+def run_vcs(command, *args, cwd=".", capture_output=True, check=False,
+            verbose=False, **run_kwargs):
+    """Run a vcs command as subprocess by using subprocess.run()."""
+    cwd = str(cwd)
+    command2 = "{prefix}/scripts/vcs-{command}".format(command=command,
+                                                       prefix=str(TOPDIR))
+    python = sys.executable
+    args2 = [python, command2] + list(args)
+    if verbose:
+        print("run: %s (cwd=%s)" % (args2, cwd))
+    if PY37_OR_GREATER:
+        # -- SINCE py37: capture_output : bool = False
+        result = subprocess.run(args2, capture_output=capture_output,
+                                cwd=cwd, check=check, **run_kwargs)
+    else:
+        # -- CASE py35, py36:
+        result = subprocess.run(args2, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                cwd=cwd, check=check, **run_kwargs)
+    return result
+
+
+def assert_repositories_output_matches(output, expected, encoding='UTF-8'):
+    """Assert that vcs-export output matches the expected output.
+
+    * Ignores any diagnostic output that occurs before repositories dump
+    * Ignores any trailing whitespace-line diffs
+    * Converts output, expected-output from bytes into string
+      for better diffs in pytest (if assertion fails)
+    """
+    # -- CONVERT BYTES-TO-STRING
+    # REASON: Better diffs in assert-statements
+    output2 = output
+    expected2 = expected
+    if not isinstance(output, str):
+        output2 = output.decode(encoding=encoding).rstrip()
+    if not isinstance(expected, str):
+        expected2 = expected.decode(encoding=encoding).rstrip()
+
+    # -- STEP: Discover begin of repository-dump
+    pos = output2.index("repositories:")
+    assert pos >= 0, "REQUIRE: repositories in output:\n%s" % output2
+    output2 = output2[pos:]
+
+    # -- VERIFY:
+    assert output2 == expected2
+
+
+# -----------------------------------------------------------------------------
+# TEST FIXTURES
+# -----------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def workspace_without_anchor(tmp_path_factory):  # noqa: E501
+    """Create workspace with imported repos (export: CASE 1).
+
+    * Without anchor-directory / anchor-repository
+    * Multiple repositories
+
+    .. notes::
+
+        * FIXTURE LIFECYCLE: Only setup/teardown once per test-session.
+        * WORKSPACE LIFECYCLE:
+          workspace directory (tmp_path) is automatically cleaned up
+        * workspace directory resides in a tmp-directory
+
+    .. seealso:: `tmp_path <https://docs.pytest.org/en/stable/tmpdir.html>`_
+
+    :return: Workspace directory (as pathlib.Path) as temporary directory.
+    """
+    workspace_directory = tmp_path_factory.mktemp("workspace_without_anchor")
+    print("workspace_without_anchor: directory={0}".format(workspace_directory))  # noqa: E501
+    yield make_imported_workspace_by_name(workspace_directory,
+                                          name="export_case1")
+    # -- CLEANUP:
+    shutil.rmtree(workspace_directory, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def workspace_with_anchor(tmp_path_factory):
+    """Create workspace with imported repos (export: CASE 2A, 2B).
+
+    * With anchor-directory / anchor-repository
+    * With sub-repository(s) below anchor-directory
+
+    :return: Workspace (temporary) directory (as pathlib.Path)
+    """
+    workspace_directory = tmp_path_factory.mktemp("workspace_with_anchor")
+    print("workspace_with_anchor: directory={0}".format(workspace_directory))  # noqa: E501
+    yield make_imported_workspace_by_name(workspace_directory,
+                                          name="export_case2")
+    # -- CLEANUP:
+    shutil.rmtree(workspace_directory, ignore_errors=True)
+
+
+# -----------------------------------------------------------------------------
+# TEST SUITE
+# -----------------------------------------------------------------------------
+class TestExportCommand:
+    NESTED_ARGS = ['--nested', '--exact-with-tags']
+
+    def test_export_case1(self, workspace_without_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS,
+                             cwd=workspace_directory)
+        print_output(output)
+        expected = get_expected_output('export_case1.exported')
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_cwd_subdir(self, workspace_without_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested
+        # with: CWD=immutable
+        workspace_directory = workspace_without_anchor
+        output = run_command('export', args=self.NESTED_ARGS,
+                             cwd=str(workspace_directory/"immutable"))
+        print_output(output)
+        expected_name = 'export_case1.cwd_subdir.exported'
+        expected = get_expected_output(expected_name)
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_subdir_arg(self, workspace_without_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested immutable
+        # with: CWD=.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS + ['immutable'],
+                             cwd=workspace_directory)
+        print_output(output)
+        # -- SAME AS: export_case1.exported
+        # REASON: paths select only directory-subtree to include in export
+        expected = get_expected_output('export_case1.exported')  # noqa: E501
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_subdir2_arg(self, workspace_without_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested immutable/vcstool_tag
+        # with: CWD=.
+        # NOTE: Selects only immutable/vcstool_tag repository to be included.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS + [
+                             'immutable/vcstool_tag'],
+                             cwd=workspace_directory)
+        print_output(output)
+        expected = get_expected_output('export_case1.with_subdir2.exported')  # noqa: E501
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_many_paths_args(self, workspace_without_anchor):    # noqa: E501
+        # -- USECASE: vcs export --nested immutable/vcstool_tag immutable/vcstool_master  # noqa: E501
+        # with: CWD=.
+        # NOTE: Manually selects both repositories (ALL-REPOS) to be included.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS + [
+                             'immutable/vcstool_tag',
+                             'immutable/vcstool_master'],
+                             cwd=workspace_directory)
+        print_output(output)
+        # -- SAME AS: export_case1.exported => Includes ALL-REPOS.
+        expected = get_expected_output('export_case1.exported')  # noqa: E501
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_viewpoint_subdir(self, workspace_without_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested --view-point=immutable
+        # with: CWD=.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS + [
+                             '--view-point=immutable'],
+                             cwd=workspace_directory)
+        print_output(output)
+        expected = get_expected_output('export_case1.viewpoint_subdir.exported')  # noqa: E501
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case1_with_viewpoint_subdir_and_subdir_arg(self, workspace_without_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested --view-point=immutable immutable
+        # with: CWD=.
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export', args=self.NESTED_ARGS + [
+                             '--view-point=immutable', 'immutable'],
+                             cwd=workspace_directory)
+        print_output(output)
+        # -- SAME AS: export_case1.cwd_subdir.exported
+        expected = get_expected_output('export_case1.cwd_subdir.exported')  # noqa: E501
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2a(self, workspace_with_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=anchor
+        workspace_directory = workspace_with_anchor
+        output = run_command('export', args=self.NESTED_ARGS,
+                             cwd=str(workspace_directory/"anchor"))
+        print_output(output)
+        expected = get_expected_output('export_case2a.exported')
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2a_with_viewpoint_parentdir(self, workspace_with_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested --view-point=..
+        # with: CWD=anchor
+        workspace_directory = workspace_with_anchor
+        output = run_command('export',
+                             args=self.NESTED_ARGS + ['--view-point=..'],
+                             cwd=str(workspace_directory/"anchor"))
+        print_output(output)
+
+        # -- SAME AS: export_case2b.exported
+        expected = get_expected_output('export_case2b.exported')
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2a_with_subdir1_arg(self, workspace_with_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested immutable
+        # with: CWD=anchor
+        # NOTE: Select only subdir repository(s) to be included in vcs-export
+        workspace_directory = workspace_with_anchor
+        output = run_command('export', args=self.NESTED_ARGS + ['immutable'],
+                             cwd=str(workspace_directory/"anchor"))
+        print_output(output)
+        expected_name = 'export_case2a.with_subdir.exported'
+        expected = get_expected_output(expected_name)
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2a_with_viewpoint_and_subdir1_arg(self, workspace_with_anchor):  # noqa: E501
+        # -- USECASE: vcs export --nested --viewpoint=immutable immutable
+        # with: CWD=anchor
+        # NOTE: Select only subdir repository(s) to be included in vcs-export
+        workspace_directory = workspace_with_anchor
+        output = run_command('export', args=self.NESTED_ARGS + [
+                             '--view-point=immutable', 'immutable'],
+                             cwd=str(workspace_directory/"anchor"))
+        print_output(output)
+        expected_name = 'export_case2a.with_viewpoint_and_subdir.exported'  # noqa: E501
+        expected = get_expected_output(expected_name)
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2b(self, workspace_with_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=.
+        workspace_directory = str(workspace_with_anchor)
+        output = run_command('export', args=self.NESTED_ARGS,
+                             cwd=workspace_directory)
+        print_output(output)
+        expected = get_expected_output('export_case2b.exported')
+        assert_repositories_output_matches(output, expected)
+
+    def test_export_case2b_with_viewpoint_anchor(self, workspace_with_anchor):
+        # -- USECASE: vcs export --nested --view-point=anchor
+        # with: CWD=.
+        workspace_directory = str(workspace_with_anchor)
+        output = run_command('export',
+                             args=self.NESTED_ARGS + ['--view-point=anchor'],
+                             cwd=workspace_directory)
+        print_output(output)
+        # -- SAME AS: export_case2a.exported
+        expected = get_expected_output('export_case2a.exported')
+        assert_repositories_output_matches(output, expected)
+
+
+class TestExportImportIdempotency:
+    """Ensures that the export/import/export cycle is idempotent.
+
+    * CASE 1
+    * CASE 2A
+    * CASE 2B
+    """
+
+    NESTED_ARGS = ['--nested', '--exact-with-tags']
+
+    @classmethod
+    def run_export_import_export(cls, directory, export_cwd=None,
+                                 import_cwd=None, import_dir=None,
+                                 export_expected=None, **run_kwargs):
+        export_cwd = str(export_cwd or directory)
+        import_cwd = str(import_cwd or directory)
+
+        # -- ENSURE: Current vcstool implementation is used.
+        # Setup PYTHONPATH to ensure subprocess.run() use it.
+        env = run_kwargs.pop('env', {})
+        env['PYTHONPATH'] = str(TOPDIR)
+        run_kwargs['env'] = env
+
+        # -- STEP 1: export-1
+        result = run_vcs('export', *cls.NESTED_ARGS,
+                         cwd=export_cwd, **run_kwargs)
+        output1 = b'%s\n%s' % (result.stdout, result.stderr or b'')
+        print_output(output1)
+        print('----')
+        assert result.returncode == 0
+        if export_expected:
+            assert_repositories_output_matches(output1, export_expected)
+
+        print("directory:  {}".format(directory))
+        print("import_cwd: {}".format(import_cwd))
+        print("export_cwd: {}".format(export_cwd))
+        output1 = result.stdout
+        repos_file = directory/"my.repos"
+        repos_file.write_bytes(output1)
+
+        # -- STEP 2: import
+        result = run_vcs('import', '--input={}'.format(repos_file),
+                         str(import_dir or '.'),
+                         cwd=import_cwd, **run_kwargs)
+        output = b'%s\n%s' % (result.stdout, result.stderr or b'')
+        print_output(output)
+        print('----')
+        assert result.returncode == 0
+
+        # -- STEP 3: export-2
+        result = run_vcs('export', *cls.NESTED_ARGS, cwd=export_cwd,
+                         **run_kwargs)
+        output2 = b'%s\n%s' % (result.stdout, result.stderr or b'')
+        print_output(output2)
+        repos_file.unlink()
+        return output1, output2
+
+    def test_export_case1(self, workspace_without_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=.
+        workspace_directory = workspace_without_anchor
+        output1, output2 = self.run_export_import_export(workspace_directory)
+
+        expected = get_expected_output('export_case1.exported')
+        assert_repositories_output_matches(output1, output2)
+        assert_repositories_output_matches(output1, expected)
+
+    def test_export_case2b(self, workspace_with_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=.
+        workspace_directory = workspace_with_anchor
+        output1, output2 = self.run_export_import_export(workspace_directory)
+
+        expected = get_expected_output('export_case2b.exported')
+        assert_repositories_output_matches(output1, output2)
+        assert_repositories_output_matches(output1, expected)
+
+    def test_export_case2a(self, workspace_with_anchor):
+        # -- USECASE: vcs export --nested
+        # with: CWD=anchor
+        workspace_directory = workspace_with_anchor
+        expected = get_expected_output('export_case2a.exported')
+        output1, output2 = self.run_export_import_export(
+            workspace_directory,
+            export_cwd=workspace_directory/"anchor",
+            import_dir="anchor",
+            export_expected=expected
+        )
+
+        assert_repositories_output_matches(output1, output2)
+        assert_repositories_output_matches(output1, expected)
+
+
+class TestVcsExportProgramOptions:
+    """Ensure that the some command-line options have the desired behavior.
+
+    TESTED COMMAND LINE OPTIONS:
+
+    * ``--view-point=<DIRECTORY>``
+    """
+
+    @pytest.mark.parametrize("viewpoint", [
+        ".", "..", "immutable", "immutable/.."
+    ])
+    def test_viewpoint_with_existing_directory_succeeds(
+            self, workspace_without_anchor, viewpoint):    # noqa: E501
+        workspace_directory = str(workspace_without_anchor)
+        output = run_command('export',
+                             args=['--view-point={0}'.format(viewpoint)],
+                             cwd=workspace_directory)
+        print_output(output)
+
+    @pytest.mark.parametrize("viewpoint", [
+        "__UNKNOWN_DIR__", "immutable/__UNKNOWN_DIR__", "../__UNKNOWN_DIR__"
+    ])
+    def test_viewpoint_with_non_existing_directory_fails(
+            self, viewpoint, workspace_without_anchor):  # noqa: E501
+        workspace_directory = workspace_without_anchor
+        result = run_vcs('export', '--view-point={0}'.format(viewpoint),
+                         cwd=workspace_directory)
+
+        # -- DIAGNOSTICS:
+        print("result.returncode={}".format(result.returncode))
+        print(result.stdout.decode(encoding="UTF-8"))
+        print("----")
+        print(result.stderr.decode(encoding="UTF-8"))
+
+        command_success = (result.returncode == 0)
+        expected = b"viewpoint=%s: directory does not exist" % \
+                   viewpoint.encode(encoding="UTF-8")
+        assert expected in result.stderr
+        assert not command_success

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -334,14 +334,14 @@ invocation.
         self.assertEqual(output, expected)
 
 
-def run_command(command, args=None, subfolder=None):
+def run_command(command, args=None, cwd=None, subfolder=None):
     repo_root = os.path.dirname(os.path.dirname(__file__))
     script = os.path.join(repo_root, 'scripts', 'vcs-' + command)
     env = dict(os.environ)
     env.update(
         LANG='en_US.UTF-8',
         PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''))
-    cwd = TEST_WORKSPACE
+    cwd = cwd or TEST_WORKSPACE
     if subfolder:
         cwd = os.path.join(cwd, subfolder)
     output = subprocess.check_output(

--- a/test/workspace_util.py
+++ b/test/workspace_util.py
@@ -1,0 +1,38 @@
+# -*- coding_ UTF-8 -*-
+"""Test support for pytest test functionality related to :mod:`vcstool` module."""  # noqa: E501
+
+# -- HINT: Test support functionality should be refactored out into own module
+import os
+from pathlib import Path
+from test.test_commands import get_expected_output, run_command
+
+
+# -- SETUP PYTHON SEARCH PATH:
+HERE = Path(__file__).parent.resolve()
+VERBOSE = os.environ.get("VERBOSE", "no") == "yes"
+
+
+# -----------------------------------------------------------------------------
+# TEST SUPPORT
+# -----------------------------------------------------------------------------
+def make_imported_workspace(directory, repos_filename, expected_output_name):
+    repos_filename = Path(repos_filename)
+    if not repos_filename.is_absolute():
+        repos_filename = Path(HERE/repos_filename).resolve()
+
+    output = run_command('import', ['--input=%s' % repos_filename],
+                         cwd=str(directory))
+    if VERBOSE:
+        print(output.decode(encoding="UTF-8"))
+
+    # -- HINT: newer git versions don't append three dots after the commit hash
+    expected = get_expected_output(expected_output_name)
+    assert output == expected or output == expected.replace(b'... ', b' ')
+    return directory
+
+
+def make_imported_workspace_by_name(directory, name):
+    repos_filename = '{0}.repos'.format(name)
+    expected_output_name = '{0}.imported'.format(name)
+    return make_imported_workspace(directory, repos_filename,
+                                   expected_output_name)


### PR DESCRIPTION
Fixes #177.

Details of changes/concepts are described in detail in the module docstring of the `test/test_command_export.py` file.

CHANGES:

* vcs-export: `paths` -- Changed to cardinality=0..N many (was: cardinality=0..1 optional)

    LINE: add_common_arguments(parser, skip_hide_empty=True, path_nargs='*') # was: path_nargs='?'
    REASON:
    * paths are used to select which directory-subtrees are included in vcs-export.
    * cardinality should be many instead of optional

* vcs-export: `--view-point : path = "."` (NEW-OPTION; cardinality=0..1 optional)

    Specifies from which directory the repository-path(s) is described.

FIXES:

* FIX: #188 python setup.py sdist problem: test/ directory is imcomplete
  Contains test/*.py files but *.repos, *.txt files are missing.
  Therefore, this will lead to test failures if the SDIST is used and tests are run.

* FIX: #187 WEIRD-PIP-INSTALL-PROBLEM: Related to vcstool-completion/vcs.fish
  => setup.py: MISSING-TRAILING-COMMA after: 'vcstool-completion/vcs.zsh'
