### PR TITLE
[log] merge-only option

### DIFF
--- a/test/log_merges_only.txt
+++ b/test/log_merges_only.txt
@@ -1,0 +1,18 @@
+=== . (git) ===
+commit f01ce3845fa0783bef9f97545e518e0f02cd509a
+Merge: 14f9968 e7770d3
+Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
+
+    Merge pull request #44 from dirk-thomas/fix_loop_exit
+
+commit 418cd63cc242aeb19bff17696adf1617b9c994b7
+Merge: 6fdb8e8 89448bd
+Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
+
+    Merge pull request #42 from dirk-thomas/fix_depends_regression
+
+commit a3c4c33d9e958a5d297e2d1d777fe2d850b2566f
+Merge: a5dfaac 8a7101c
+Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>
+
+    Merge pull request #41 from dirk-thomas/parent_path_dependencies

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -103,6 +103,12 @@ class TestCommands(unittest.TestCase):
         expected = get_expected_output('log_limit')
         self.assertEqual(output, expected)
 
+    def test_log_merge_only(self):
+        output = run_command(
+            'log', args=['--merge-only'], subfolder='immutable/tag')
+        expected = get_expected_output('log_merges_only')
+        self.assertEqual(output, expected)
+
     def test_pull(self):
         output = run_command('pull', args=['--workers', '1'])
         expected = get_expected_output('pull')

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -537,10 +537,10 @@ class GitClient(VcsClientBase):
                 return result_tag
             # output log since nearest tag
             cmd = [GitClient._executable, 'log', '%s..' % result_tag['output']]
-        elif command.merge_only:
-            cmd = [GitClient._executable, 'log', '--merges']
         else:
             cmd = [GitClient._executable, 'log']
+        if command.merge_only:
+            cmd += ['--merges']
         cmd += ['--decorate']
         if command.limit != 0:
             cmd += ['-%d' % command.limit]

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -537,6 +537,8 @@ class GitClient(VcsClientBase):
                 return result_tag
             # output log since nearest tag
             cmd = [GitClient._executable, 'log', '%s..' % result_tag['output']]
+        elif command.merge_only:
+            cmd = [GitClient._executable, 'log', '--merges']
         else:
             cmd = [GitClient._executable, 'log']
         cmd += ['--decorate']

--- a/vcstool/commands/log.py
+++ b/vcstool/commands/log.py
@@ -17,6 +17,7 @@ class LogCommand(Command):
         self.limit = args.limit
         self.limit_tag = args.limit_tag
         self.limit_untagged = args.limit_untagged
+        self.merge_only = args.merge_only
         self.verbose = args.verbose
 
 
@@ -34,6 +35,9 @@ def get_parser():
     ex_group.add_argument(
         '--limit-untagged', action='store_true', default=False,
         help='Limit number of log from the head to the last tagged commit')
+    group.add_argument(
+        '--merge-only', action='store_true', default=False,
+        help='Show only merge commits')
     group.add_argument(
         '--verbose', action='store_true', default=False,
         help='Show the full commit message')


### PR DESCRIPTION
# Problem, approach
See https://github.com/dirk-thomas/vcstool/issues/174

# Example operation and out put

```
# git checkout 0.1.27
# vcs-log --merge-only
=== . (git) ===
commit d82cb6ec3be31533dc90979e083072c6440c68d3
Merge: dcee1a0 c174cd8
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>

    Merge pull request #61 from dirk-thomas/use_pytest

commit 68a2451d33c4f4de6f148de57439f08f0330d898
Merge: f7f008a 93eb8c6
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>

    Merge pull request #58 from dirk-thomas/support_nested_repos

commit f7f008a1279dce9b213c9cfc9e72a2f1fbf73c33
Merge: 3d98c90 3d8d011
Author: Dirk Thomas <dirk-thomas@users.noreply.github.com>

    Merge pull request #59 from dirk-thomas/flake8
```

# Open question
- This PR at the time of writing just adds a simple wrapper for underlining `vcs` tool, without new advantage. The design with `custom` verb to delegate commands to each `vcs` tool seems to be a right approach. I can agree to close this PR if a simple change like what's in this PR is undesirable.
   - What I envisioned originally was to take advantage of `vcstool`'s unique functionality and run a command against multiple local repos. Something like this (Obviously the argument `oneline` doesn't yet exist so the command failed):
      ```
      # vcs-log --merge-only --oneline
      usage: vcs log [-h] [-l N] [--limit-tag TAG | --limit-untagged] [--merge-only] [--verbose] [--debug] [-s] [-n] [-w N] [--repos] [paths [paths ...]]
      vcs log: error: unrecognized arguments: --oneline
      ```
      Then I found `custom` verb lets you easily achieve what I wanted.
      ```
      # vcs-custom --git --args log --oneline --merges -n 10
      ...
      === ./ros_tutorials (git) ===
      f40abd5 Merge pull request #31 from JavaJeremy/ThetaBugfix
      626a3e5 Merge pull request #35 from jproft/kinetic-devel
      f21c4d2 Merge pull request #29 from ros/fix_compiler_warnings_jade
      d6d11f3 Merge pull request #27 from gusmonod/patch-1
      36715e2 Merge pull request #23 from adamheins/jade-devel
      9a1f606 Merge pull request #22 from ros/jade-devel-add-turtle
      :
      === ./vcstool (git) ===
      d82cb6e Merge pull request #61 from dirk-thomas/use_pytest
      68a2451 Merge pull request #58 from dirk-thomas/support_nested_repos
      f7f008a Merge pull request #59 from dirk-thomas/flake8
      3d98c90 Merge pull request #55 from dirk-thomas/style
      3a687d2 Merge pull request #54 from dirk-thomas/convert_version_to_string
      :
      ```

