### PR TITLE
Detect special POSIX shells on Windows and output POSIX paths

### DIFF
--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -81,11 +81,13 @@ def get_ready_job(jobs):
 def execute_jobs(
     jobs, show_progress=False, number_of_workers=10, debug_jobs=False
 ):
+    global windows_force_posix
     from vcstool.streams import stdout
     if debug_jobs:
         logger.setLevel(logging.DEBUG)
 
-    logger.debug('force POSIX paths on Windows: %s' % windows_force_posix)
+    if windows_force_posix:
+        logger.debug('force POSIX paths on Windows')
 
     results = []
 

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -14,7 +14,10 @@ logging.basicConfig()
 # output POSIX paths, i.e. forward slashes only
 windows_force_posix = \
     sys.platform == 'win32' and '/' in os.environ.get('_', '')
+
+
 def fix_output_path(path):
+    global windows_force_posix
     return path.replace('\\', '/') if windows_force_posix else path
 
 
@@ -23,7 +26,9 @@ def output_repositories(clients):
     ordered_clients = {client.path: client for client in clients}
     for k in sorted(ordered_clients.keys()):
         client = ordered_clients[k]
-        print('%s (%s)' % (fix_output_path(k), client.__class__.type), file=stdout)
+        print(
+            '%s (%s)' % (fix_output_path(k), client.__class__.type),
+            file=stdout)
 
 
 def generate_jobs(clients, command):


### PR DESCRIPTION
Closes #202

The real problem is that some special shells on Windows may not support backslashes at all.

* PowerShell supports mixed slashes
* CMD mostly doesn't
* bash (installed along with Git for Windows) only supports forward slashes

I've tried to find a simple method to detect special shells like this, since we preferably only want to change the current behaviour for those shells, although it's okay to change the behaviour for shells that support mixed styles. I looked into `MSYSTEM` but ultimately found that checking if `$_` exists and contains a forward slash seems to work fine.

> **Special Parameters**
> **_**
> At shell startup, set to the absolute pathname used to invoke the shell or shell script being executed as passed in the environment or argument list. Subsequently, expands to the last argument to the previous command, after expansion. Also set to the full pathname used to invoke each command executed and placed in the environment exported to that command.  [...]
> https://linux.die.net/man/1/bash

Note that this PR only affects the paths that are printed (1) as part of the results and (2) when using the `--repos` option. I didn't want to change anything else (e.g. applying the path fix in the crawling step), because that seems to be working fine the way it is.

Finally, as a follow-up to the concrete downstream issue described in https://github.com/ros-tooling/action-ros-ci/issues/578, I did try the fix from this PR and it works. The bash shell is detected on Windows and `vcstool` prints POSIX paths. I also tested manually, and it doesn't change the current behaviour for PowerShell or CMD.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>