### PR TITLE
Make CI jobs use matrix.os value and fix tests for macOS & Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -33,4 +33,4 @@ jobs:
       run: |
         pip install --upgrade coverage flake8 flake8-docstrings flake8-import-order pytest
         git config --global --add init.defaultBranch master
-        PYTHONPATH=`pwd` pytest -s -v test
+        ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade PyYAML
+    - name: Install dependencies (macOS)
+      run: |
+        brew install subversion mercurial
+      if: matrix.os == 'macos-latest'
     - name: Test with pytest
       run: |
         pip install --upgrade coverage flake8 flake8-docstrings flake8-import-order pytest
         git config --global --add init.defaultBranch master
+        git config --global --add advice.detachedHead true
         ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         include:
         - os: macos-latest
           python-version: 3.8
-        - os: windows-latest
-          python-version: 3.8
+        # - os: windows-latest
+        #   python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         include:
         - os: macos-latest
           python-version: 3.8
-        # - os: windows-latest
-        #   python-version: 3.8
+        - os: windows-latest
+          python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -191,12 +191,12 @@ or --ff-only on the command line to override the configured default per
 invocation.
 """
             output = output.replace(pull_warning, '')
-        output = adapt_command_output(output.encode())
-        # the output was retrieved through a different way here and
-        # it does not include carriage return characters on Windows
+        # the output was retrieved through a different way here
+        output = adapt_command_output(output.encode()).decode()
         if sys.platform == 'win32':
-            output = output.replace(b'\n', b'\r\n')
-        expected = get_expected_output('pull')
+            # it does not include carriage return characters on Windows
+            output = output.replace('\n', '\r\n')
+        expected = get_expected_output('pull').decode()
         assert output == expected
 
     def test_reimport(self):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -352,6 +352,22 @@ invocation.
         self.assertEqual(output, expected)
 
 
+def run_command(command, args=None, subfolder=None):
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    script = os.path.join(repo_root, 'scripts', 'vcs-' + command)
+    env = dict(os.environ)
+    env.update(
+        LANG='en_US.UTF-8',
+        PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''))
+    cwd = TEST_WORKSPACE
+    if subfolder:
+        cwd = os.path.join(cwd, subfolder)
+    output = subprocess.check_output(
+        [sys.executable, script] + (args or []),
+        stderr=subprocess.STDOUT, cwd=cwd, env=env)
+    return adapt_command_output(output, cwd)
+
+
 def adapt_command_output(output, cwd=None):
     assert type(output) == bytes
     # replace message from older git versions
@@ -406,22 +422,6 @@ def adapt_command_output(output, cwd=None):
         for before, after in paths_to_replace:
             output = output.replace(before, after)
     return output
-
-
-def run_command(command, args=None, subfolder=None):
-    repo_root = os.path.dirname(os.path.dirname(__file__))
-    script = os.path.join(repo_root, 'scripts', 'vcs-' + command)
-    env = dict(os.environ)
-    env.update(
-        LANG='en_US.UTF-8',
-        PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''))
-    cwd = TEST_WORKSPACE
-    if subfolder:
-        cwd = os.path.join(cwd, subfolder)
-    output = subprocess.check_output(
-        [sys.executable, script] + (args or []),
-        stderr=subprocess.STDOUT, cwd=cwd, env=env)
-    return adapt_command_output(output, cwd)
 
 
 def get_expected_output(name):


### PR DESCRIPTION
There was a strategy matrix, but all jobs were running on `ubuntu-latest`.

Tests run fine on macOS if I set `advice.detachedHead` to `true` (I think it's off by default on newer git versions, and macOS has a more recent version).

For Windows, it's a bit more complicated because of the different path separator. It required some more manual adjustments to the test code.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>