### PR TITLE
Update ROS repository key instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,8 @@ On Ubuntu this is done using *apt-get*:
 If you are using `ROS <https://www.ros.org/>`_ you can get the package directly from the ROS repository::
 
   sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xAB17C654
+  sudo apt install curl # if you haven't already installed curl
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
   sudo apt-get update
   sudo apt-get install python3-vcstool
 


### PR DESCRIPTION
Closes #224

This updates the instructions for adding the ROS repository key to the most recent instructions here: http://wiki.ros.org/noetic/Installation/Ubuntu#Installation.2FUbuntu.2FSources.Set_up_your_keys.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>