### PR TITLE
Update release distributions.

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -8,8 +8,8 @@ artifacts:
         config:
           repository: dirk-thomas/vcstool
           distributions:
-            - ubuntu:xenial
             - ubuntu:bionic
             - ubuntu:focal
-            - debian:stretch
+            - ubuntu:jammy
             - debian:buster
+            - debian:bullseye


### PR DESCRIPTION
* Drop Ubuntu Xenial which ended public support in April 2021
* Drop Debian Stretch which stopped receiving security updates in July
  2021
* Add Ubuntu Jammy which is the forthcoming LTS in April 2022
* Add Debian Bullseye which is the current stable release of Debian

The ROS repositories for Bullseye and Jammy are coming online.
The proposed changes here match the changes being made to ROS infrastructure packages but I am more interested in the added distributions than the dropped ones.

If this PR is accepted I'll also update the vcstool configs in [reprepro-updater](https://github.com/ros-infrastructure/reprepro-updater) so that future vcstool releases are ready for import in the new distributions.