### PR TITLE
Fix: UnboundLocalError: local variable 'version_type' referenced before assignment

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -725,6 +725,8 @@ class GitClient(VcsClientBase):
             else:
                 for _hash in hashes:
                     if _hash.startswith(command.version):
+                        version_type = 'hash'
+                        version_name = command.version
                         break
                 else:
                     cmd = result_ls_remote['cmd']


### PR DESCRIPTION
`vcs validate` fails if version is referred to git hash due to unbounded variable error like below.

```
=== <package> (git) ===
Invocation of command 'validate' on client 'git' failed: UnboundLocalError: local variable 'cmd' referenced before assignment (/usr/lib/python3/dist-packages/vcstool/clients/git.py:736)
```
