### PR TITLE
Ci fixes: Update python version coverage and flake8 dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         include:
         - os: macos-latest
-          python-version: 3.8
+          python-version: 3.10
         - os: windows-latest
           python-version: 3.8
+        - os: windows-latest
+          python-version: 3.10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
         - os: macos-latest
-          python-version: 3.10
+          python-version: "3.10"
         - os: windows-latest
-          python-version: 3.8
+          python-version: "3.8"
         - os: windows-latest
-          python-version: 3.10
+          python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       if: matrix.os == 'macos-latest'
     - name: Test with pytest
       run: |
-        pip install --upgrade coverage flake8 flake8-docstrings flake8-import-order pytest
+        pip install --upgrade .[test]
+        pip install --upgrade coverage
         git config --global --add init.defaultBranch master
         git config --global --add advice.detachedHead true
         ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,21 @@ from setuptools import find_packages
 from setuptools import setup
 from vcstool import __version__
 
-install_requires = ['PyYAML', 'setuptools']
-
 setup(
     name='vcstool',
     version=__version__,
-    install_requires=install_requires,
+    install_requires=[
+        'PyYAML',
+        'setuptools'],
+    extras_require={
+        'test': [
+            'flake8 >= 3.7, < 5',
+            'flake8-docstrings',
+            'flake8-import-order',
+            'pycodestyle < 2.9.0',
+            'pyflakes < 2.5.0',
+            'pytest']
+        },
     packages=find_packages(),
     author='Dirk Thomas',
     author_email='web@dirk-thomas.net',


### PR DESCRIPTION
This sequence of PRs gets the GitHub Actions CI running again.

The following changes are included:

* Update the python versions covered to 3.6 - 3.10 on the latest Ubuntu, 3.10 on macOS, and 3.8, 3.10 on Windows (3.8 is still used by ROS 2), python versions are also string quoted so yaml does not interpret `3.10` as `3.1`.
* Move test dependencies to extras_require.test following the conventions adopted for ROS infrastructure packages.
* Add a requirement for flake8 < 5 due to breaking changes. The ROS infra team will be looking further at flake8 5 compatibility in the coming weeks and I hope to apply whatever we do there to vcstool as well. This gets CI operational in the meantime.