### PR TITLE
Relative git url

### DIFF
--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -33,9 +33,10 @@ class VcsClientBase(object):
             'returncode': NotImplemented
         }
 
-    def _run_command(self, cmd, env=None, retry=0):
+    def _run_command(self, cmd, cwd=None, env=None, retry=0):
+        cwd = cwd if cwd else os.path.abspath(self.path)
         for i in range(retry + 1):
-            result = run_command(cmd, os.path.abspath(self.path), env=env)
+            result = run_command(cmd, cwd, env=env)
             if not result['returncode']:
                 # return successful result
                 break


### PR DESCRIPTION
Allows resolution of git paths relative to the next upper git repository.


* adds import function for relative git urls
* adds export functionality for relative git urls
* automatically makes urls relative if possible
* Solves conflicts between https:// and ssh (git@) urls


close #204 