### PR TITLE
Provide clearer error message when repository entry is empty

### DIFF
--- a/test/bad.repos
+++ b/test/bad.repos
@@ -1,0 +1,4 @@
+repositories:
+  empty_entry:
+  missing_url:
+    type: git

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -16,6 +16,7 @@ REPOS_FILE_URL = file_uri_scheme + REPOS_FILE
 REPOS2_FILE = os.path.join(os.path.dirname(__file__), 'list2.repos')
 TEST_WORKSPACE = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), 'test_workspace')
+BAD_REPOS_FILE = os.path.join(os.path.dirname(__file__), 'bad.repos')
 
 CI = os.environ.get('CI') == 'true'  # Travis CI / Github actions set: CI=true
 svn = which('svn')
@@ -324,6 +325,11 @@ invocation.
         output = run_command(
             'validate', ['--hide-empty', '--input', REPOS_FILE])
         expected = get_expected_output('validate_hide')
+        self.assertEqual(output, expected)
+
+        output = run_command(
+            'validate', ['--input', BAD_REPOS_FILE])
+        expected = get_expected_output('validate_bad')
         self.assertEqual(output, expected)
 
     @unittest.skipIf(not svn and not CI, '`svn` was not found')

--- a/test/validate_bad.txt
+++ b/test/validate_bad.txt
@@ -1,0 +1,2 @@
+Repository 'empty_entry' is empty
+Repository 'missing_url' does not provide the necessary information: 'url'

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -102,6 +102,12 @@ def get_repos_in_vcstool_format(repositories):
     for path in repositories:
         repo = {}
         attributes = repositories[path]
+        if not attributes:
+            print(
+                ansi('yellowf') + (
+                    "Repository '%s' is empty" % path) + ansi('reset'),
+                file=sys.stderr)
+            continue
         try:
             repo['type'] = attributes['type']
             repo['url'] = attributes['url']


### PR DESCRIPTION
Fixes #255

The parsing code (`get_repos_in_vcstool_format()`) already provides a useful error message when an attribute is missing (e.g., `url:`). However, as shown in the issue above, it doesn't handle/detect empty repository entries. Therefore, check if the repository is empty before trying to access its attributes. Otherwise, provide a useful error message:

```
$ cat bad.repos
repositories:
  empty_entry:
  missing_url:
    type: git
$ vcs validate --input bad.repos 
Repository 'empty_entry' is empty
Repository 'missing_url' does not provide the necessary information: 'url'
```

Before this change, validation fails on `empty_entry` (and does not validate `missing_url`):

```
$ vcs validate --input bad.repos 
Input data is not valid format: 'NoneType' object is not subscriptable
```

I've also updated the tests to cover this.