### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         pip install --upgrade coverage flake8 flake8-docstrings flake8-import-order pytest
         git config --global --add init.defaultBranch master
         git config --global --add advice.detachedHead true
-        ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test
+        ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test ${{ matrix.os != 'ubuntu-latest' && '-k "not test_flake8"' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: macos-latest
-          python-version: 3.8
+          python-version: '3.8'
         - os: windows-latest
-          python-version: 3.8
+          python-version: '3.8'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import find_packages
 from setuptools import setup
+
 from vcstool import __version__
 
 install_requires = ['PyYAML', 'setuptools']

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -3,7 +3,6 @@ from shutil import which
 import subprocess
 
 from vcstool.executor import USE_COLOR
-
 from .vcs_base import VcsClientBase
 from ..util import rmtree
 

--- a/vcstool/clients/hg.py
+++ b/vcstool/clients/hg.py
@@ -3,7 +3,6 @@ from shutil import which
 from threading import Lock
 
 from vcstool.executor import USE_COLOR
-
 from .vcs_base import VcsClientBase
 from ..util import rmtree
 

--- a/vcstool/commands/branch.py
+++ b/vcstool/commands/branch.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/custom.py
+++ b/vcstool/commands/custom.py
@@ -8,7 +8,6 @@ from vcstool.executor import generate_jobs
 from vcstool.executor import output_repositories
 from vcstool.executor import output_results
 from vcstool.streams import set_streams
-
 from .command import add_common_arguments
 from .command import Command
 

--- a/vcstool/commands/diff.py
+++ b/vcstool/commands/diff.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/export.py
+++ b/vcstool/commands/export.py
@@ -9,7 +9,6 @@ from vcstool.executor import generate_jobs
 from vcstool.executor import output_repositories
 from vcstool.executor import output_results
 from vcstool.streams import set_streams
-
 from .command import add_common_arguments
 from .command import Command
 

--- a/vcstool/commands/help.py
+++ b/vcstool/commands/help.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 from pkg_resources import load_entry_point
+
 from vcstool.clients import vcstool_clients
 from vcstool.commands import vcstool_commands
 from vcstool.streams import set_streams

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -4,6 +4,8 @@ from shutil import which
 import sys
 import urllib.request as request
 
+import yaml
+
 from vcstool import __version__ as vcstool_version
 from vcstool.clients import vcstool_clients
 from vcstool.clients.vcs_base import run_command
@@ -12,8 +14,6 @@ from vcstool.executor import execute_jobs
 from vcstool.executor import output_repositories
 from vcstool.executor import output_results
 from vcstool.streams import set_streams
-import yaml
-
 from .command import add_common_arguments
 from .command import Command
 

--- a/vcstool/commands/log.py
+++ b/vcstool/commands/log.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/pull.py
+++ b/vcstool/commands/pull.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/push.py
+++ b/vcstool/commands/push.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/remotes.py
+++ b/vcstool/commands/remotes.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/status.py
+++ b/vcstool/commands/status.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 from vcstool.streams import set_streams
-
 from .command import Command
 from .command import simple_main
 

--- a/vcstool/commands/validate.py
+++ b/vcstool/commands/validate.py
@@ -7,7 +7,6 @@ from vcstool.executor import ansi
 from vcstool.executor import execute_jobs
 from vcstool.executor import output_results
 from vcstool.streams import set_streams
-
 from .command import add_common_arguments
 from .command import Command
 


### PR DESCRIPTION
* Bump actions/checkout and actions/setup-python
* Remove Python 3.5 & 3.6, since those releases are no longer active
* Add 3.9 & 3.10
* Fix `test_flake8` to support newer versions of flake8
* Set `application-import-names` and update/sort imports
* Skip `test_flake8` on macOS & Windows, since _something_ seems to be different compared to Ubuntu, which leads to a lot of violations, but we don't really need to test that on all platforms

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>