### PR TITLE
Resolve import failure on very slow/unstable networks

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -315,7 +315,7 @@ class GitClient(VcsClientBase):
             cmd_fetch = [GitClient._executable, 'fetch', remote]
             if command.shallow:
                 result_version_type, version_name = self._check_version_type(
-                    command.url, checkout_version)
+                    command.url, checkout_version, command.retry)
                 if result_version_type['returncode']:
                     return result_version_type
                 version_type = result_version_type['version_type']
@@ -379,7 +379,7 @@ class GitClient(VcsClientBase):
             version_type = None
             if command.version:
                 result_version_type, version_name = self._check_version_type(
-                    command.url, command.version)
+                    command.url, command.version, command.retry)
                 if result_version_type['returncode']:
                     return result_version_type
                 version_type = result_version_type['version_type']
@@ -497,7 +497,7 @@ class GitClient(VcsClientBase):
             'returncode': 0 if remote_urls else 1
         }
 
-    def _check_version_type(self, url, version):
+    def _check_version_type(self, url, version, retry=0):
         # check if version starts with heads/ or tags/
         prefixes = {
             'heads/': 'branch',
@@ -514,7 +514,7 @@ class GitClient(VcsClientBase):
                 }, version[len(prefix):]
 
         cmd = [GitClient._executable, 'ls-remote', url, version]
-        result = self._run_command(cmd)
+        result = self._run_command(cmd, retry=retry)
         if result['returncode']:
             result['output'] = 'Could not determine ref type of version: ' + \
                 result['output']


### PR DESCRIPTION
While working with vcs I was noticing a lot of failures when having to be on an unreliable VPN connection when running an import command. This is the failure I was seeing:

``` bash
Could not determine ref type of version: kex_exchange_identification: read: Connection reset by peer
```
After doing some debugging, I noted that vcs was erroring out when running the git **"ls-remote"** command. Upon further inspection, I noted that the retry flag was not being passed to where this command was being called. After applying the changes in this PR, vcs is now able to successfully import all my git repos on an unstable connection (with a retry flag being passed in).