### PR TITLE
clean output in `vcs pull -s` with git

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -585,7 +585,7 @@ class GitClient(VcsClientBase):
 
     def pull(self, _command):
         self._check_executable()
-        cmd = [GitClient._executable, 'pull']
+        cmd = [GitClient._executable, 'pull', '--quiet']
         self._check_color(cmd)
         result = self._run_command(cmd)
 


### PR DESCRIPTION
`--quiet` hides the default `git pull` output "Already up to date.", effectively making vcs skip the repo output with `vcs pull -s`

Compare before:
![screenshot240116-124735](https://github.com/dirk-thomas/vcstool/assets/680358/e0c1b954-df0c-498f-b5ed-ab62b970640b)

After: 
![screenshot240116-124812](https://github.com/dirk-thomas/vcstool/assets/680358/3d1458ff-0d08-4741-913f-077acc4a038f)
