### PR TITLE
Support git insteadOf config entries during import

### DIFF
--- a/test/list_ssh.repos
+++ b/test/list_ssh.repos
@@ -1,0 +1,5 @@
+repositories:  
+  vcstool:
+    type: git
+    url: git@github.com:dirk-thomas/vcstool.git
+    version: heads/master  

--- a/test/remotes_insteadof.txt
+++ b/test/remotes_insteadof.txt
@@ -1,0 +1,3 @@
+=== ./vcstool (git) ===
+origin	https://github.com/dirk-thomas/vcstool.git (fetch)
+origin	https://github.com/dirk-thomas/vcstool.git (push)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -352,20 +352,23 @@ invocation.
         self.assertEqual(output, expected)
 
 
-def run_command(command, args=None, subfolder=None):
+def run_command(command, args=None, subfolder=None, envs=None, raw_output=False):
     repo_root = os.path.dirname(os.path.dirname(__file__))
     script = os.path.join(repo_root, 'scripts', 'vcs-' + command)
     env = dict(os.environ)
     env.update(
         LANG='en_US.UTF-8',
         PYTHONPATH=repo_root + os.pathsep + env.get('PYTHONPATH', ''))
+    if envs is not None:
+        env.update(envs)
+
     cwd = TEST_WORKSPACE
     if subfolder:
         cwd = os.path.join(cwd, subfolder)
     output = subprocess.check_output(
         [sys.executable, script] + (args or []),
         stderr=subprocess.STDOUT, cwd=cwd, env=env)
-    return adapt_command_output(output, cwd)
+    return output if raw_output else adapt_command_output(output, cwd)
 
 
 def adapt_command_output(output, cwd=None):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -325,11 +325,13 @@ invocation.
 
         try:
             # git doesn't make it easy to change the location of the global .gitconfig
-            # Change HOME to avoid messing with the user's .gitconfig
-            subprocess.check_output(
-                ['git', 'config',
-                 '--global', 'url.https://github.com/.insteadof', 'git@github.com:'],
-                stderr=subprocess.STDOUT, cwd=workdir, env={'HOME': workdir})
+            # It will look for HOME/.gitconfig, so I have to override HOME and
+            # put a new gitconfig there.  The thought of overwriting the user's .gitconfig
+            # scares me, so check/write the file manually
+            gitconfig_file = os.path.join(workdir, '.gitconfig')
+            self.assertFalse(os.path.exists(gitconfig_file))
+            with open(gitconfig_file, 'w') as f:
+                f.write('[url "https://github.com/"]\n\tinsteadOf = git@github.com:\n')
 
             run_command(
                 'import', ['--input', REPOS_SSH_FILE, '.'],

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -9,7 +9,6 @@ from ..util import rmtree
 
 
 class GitClient(VcsClientBase):
-
     type = 'git'
     _executable = None
     _git_version = None
@@ -69,7 +68,7 @@ class GitClient(VcsClientBase):
             result_branch = self._run_command(cmd_branch)
             if result_branch['returncode']:
                 result_branch['output'] = 'Could not determine ref: ' + \
-                    result_branch['output']
+                                          result_branch['output']
                 return result_branch
             branch_name = result_branch['output']
             exact = branch_name == 'HEAD'  # is detached
@@ -82,7 +81,7 @@ class GitClient(VcsClientBase):
             result_remote = self._run_command(cmd_remote)
             if result_remote['returncode']:
                 result_remote['output'] = 'Could not determine ref: ' + \
-                    result_remote['output']
+                                          result_remote['output']
                 return result_remote
             branch_with_remote = result_remote['output']
 
@@ -122,7 +121,7 @@ class GitClient(VcsClientBase):
             result_ref = self._run_command(cmd_ref)
             if result_ref['returncode']:
                 result_ref['output'] = 'Could not determine ref: ' + \
-                    result_ref['output']
+                                       result_ref['output']
                 return result_ref
             ref = result_ref['output']
 
@@ -131,7 +130,7 @@ class GitClient(VcsClientBase):
             result_remotes = self._run_command(cmd_remotes)
             if result_remotes['returncode']:
                 result_remotes['output'] = 'Could not determine remotes: ' + \
-                    result_remotes['output']
+                                           result_remotes['output']
                 return result_remotes
             remotes = result_remotes['output'].splitlines()
 
@@ -218,7 +217,7 @@ class GitClient(VcsClientBase):
             GitClient._executable, 'ls-remote', '--get-url', '%s' % remote]
         result_url = self._run_command(cmd_url)
         if result_url['returncode']:
-            result_url['output'] = f'Could not resolve url for remote {remote}: ' + \
+            result_url['output'] = 'Could not resolve url for remote %s: ' % remote + \
                                    result_url['output']
         return result_url
 
@@ -237,7 +236,8 @@ class GitClient(VcsClientBase):
             return resolved_cmd_url
 
         if resolved_cmd_url['output'] != command.url:
-            print(ansi('yellowf') + f"url {command.url} was resolved to {resolved_cmd_url['output']} by insteadOf")
+            print(
+                ansi('yellowf') + 'url %s was resolved to %s' % (command.url, resolved_cmd_url['output']))
             command.url = resolved_cmd_url['output']
 
         self._check_executable()
@@ -489,7 +489,7 @@ class GitClient(VcsClientBase):
         result_remote = self._run_command(cmd_remote)
         if result_remote['returncode']:
             result_remote['output'] = 'Could not determine remotes: ' + \
-                result_remote['output']
+                                      result_remote['output']
             return result_remote
         remote_urls = []
         cmd = result_remote['cmd']
@@ -526,7 +526,7 @@ class GitClient(VcsClientBase):
         result = self._run_command(cmd)
         if result['returncode']:
             result['output'] = 'Could not determine ref type of version: ' + \
-                result['output']
+                               result['output']
             return result, None
         if not result['output']:
             result['version_type'] = 'hash'
@@ -542,7 +542,7 @@ class GitClient(VcsClientBase):
             if refs[tag_ref] != refs[branch_ref]:
                 result['returncode'] = 1
                 result['output'] = 'The version ref is a branch as well as ' \
-                    'tag but with different hashes'
+                                   'tag but with different hashes'
                 return result, None
         if tag_ref in refs:
             result['version_type'] = 'tag'
@@ -605,7 +605,7 @@ class GitClient(VcsClientBase):
             result_rev_parse = self._run_command(cmd_rev_parse)
             if result_rev_parse['returncode']:
                 result_rev_parse['output'] = 'Could not determine ref: ' + \
-                    result_rev_parse['output']
+                                             result_rev_parse['output']
                 return result_rev_parse
             detached = result_rev_parse['output'] == 'HEAD'
 
@@ -691,7 +691,7 @@ class GitClient(VcsClientBase):
             branches = []
 
             for hash_and_ref in self._get_hash_ref_tuples(
-                result_ls_remote['output']
+                    result_ls_remote['output']
             ):
                 hashes.append(hash_and_ref[0])
 
@@ -708,26 +708,26 @@ class GitClient(VcsClientBase):
                 version_type = 'ref'
                 version_name = command.version
             elif (
-                command.version.startswith('heads/') and
-                command.version[6:] in branches
+                    command.version.startswith('heads/') and
+                    command.version[6:] in branches
             ):
                 version_type = 'branch'
                 version_name = command.version[6:]
             elif (
-                command.version.startswith('tags/') and
-                command.version[5:] in tags
+                    command.version.startswith('tags/') and
+                    command.version[5:] in tags
             ):
                 version_type = 'tag'
                 version_name = command.version[5:]
             elif (
-                command.version in branches and
-                command.version not in tags
+                    command.version in branches and
+                    command.version not in tags
             ):
                 version_type = 'branch'
                 version_name = command.version
             elif (
-                command.version in tags and
-                command.version not in branches
+                    command.version in tags and
+                    command.version not in branches
             ):
                 version_type = 'tag'
                 version_name = command.version
@@ -738,8 +738,8 @@ class GitClient(VcsClientBase):
                 else:
                     cmd = result_ls_remote['cmd']
                     output = "Found git repository '%s' but " % command.url + \
-                        'unable to verify non-branch / non-tag ref ' + \
-                        "'%s' without cloning the repo" % command.version
+                             'unable to verify non-branch / non-tag ref ' + \
+                             "'%s' without cloning the repo" % command.version
 
                     return {
                         'cmd': cmd,
@@ -750,11 +750,11 @@ class GitClient(VcsClientBase):
 
             cmd = result_ls_remote['cmd']
             output = "Found git repository '%s' with %s '%s'" % \
-                (command.url, version_type, version_name)
+                     (command.url, version_type, version_name)
         else:
             cmd = result_ls_remote['cmd']
             output = "Found git repository '%s' with default branch" % \
-                command.url
+                     command.url
 
         return {
             'cmd': cmd,

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -236,8 +236,6 @@ class GitClient(VcsClientBase):
             return resolved_cmd_url
 
         if resolved_cmd_url['output'] != command.url:
-            print(
-                ansi('yellowf') + 'url %s was resolved to %s' % (command.url, resolved_cmd_url['output']))
             command.url = resolved_cmd_url['output']
 
         self._check_executable()

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -2,7 +2,7 @@ import os
 from shutil import which
 import subprocess
 
-from vcstool.executor import USE_COLOR
+from vcstool.executor import USE_COLOR, ansi
 
 from .vcs_base import VcsClientBase
 from ..util import rmtree
@@ -230,6 +230,15 @@ class GitClient(VcsClientBase):
                 'output': "Repository data lacks the 'url' value",
                 'returncode': 1
             }
+
+        # Check if the url will be modified by insteadOf
+        resolved_cmd_url = self._get_remote_url(command.url)
+        if resolved_cmd_url['returncode']:
+            return resolved_cmd_url
+
+        if resolved_cmd_url['output'] != command.url:
+            print(ansi('yellowf') + f"url {command.url} was resolved to {resolved_cmd_url['output']} by insteadOf")
+            command.url = resolved_cmd_url['output']
 
         self._check_executable()
         if GitClient.is_repository(self.path):

--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -215,11 +215,11 @@ class GitClient(VcsClientBase):
 
     def _get_remote_url(self, remote):
         cmd_url = [
-            GitClient._executable, 'config', '--get', 'remote.%s.url' % remote]
+            GitClient._executable, 'ls-remote', '--get-url', '%s' % remote]
         result_url = self._run_command(cmd_url)
         if result_url['returncode']:
-            result_url['output'] = 'Could not determine remote url: ' + \
-                result_url['output']
+            result_url['output'] = f'Could not resolve url for remote {remote}: ' + \
+                                   result_url['output']
         return result_url
 
     def import_(self, command):


### PR DESCRIPTION
ls-remote --get-url will apply any special insteadOf rules.  This prevents false "Path already exists and contains a different repository" errors if you have something like the below in your gitconfig. 
```
[url "git@github.com:"]
    insteadOf = https://github.com/
```