### PR TITLE
Add git submodule support (to detect submodule repos)

### DIFF
--- a/vcstool/clients/git.py
+++ b/vcstool/clients/git.py
@@ -28,7 +28,8 @@ class GitClient(VcsClientBase):
 
     @staticmethod
     def is_repository(path):
-        return os.path.isdir(os.path.join(path, '.git'))
+        return (os.path.isdir(os.path.join(path, '.git')) or 
+                os.path.isfile(os.path.join(path, '.git')))
 
     def __init__(self, path):
         super(GitClient, self).__init__(path)


### PR DESCRIPTION
Found that git submodules were not getting detected by `vcs`. Believe the issue comes down to file structure and type. 

(Also faced in issue: #198) 

### Typical git repo
```
git_repo
    |--- .git (directory)
```

### Submodule repo
```
outer_repo
    |--- .git (directory)
    |--- submodule_repo
         |--- .git (file)
```

Contents of `.git` file (the one inside the submodule_repo): 
```
gitdir: ../.git/modules/submodule_repo
```

So effectively, submodules don't have `.git` directory of their own but rather a `.git` linked file that links to the directory in the outer `.git` directory.

Currently, it appears that vcstool is designed to determine if a repo is a git repo by checking for only a `.git` directory:
https://github.com/dirk-thomas/vcstool/blob/daf389377310f7f31b2171f51a79af82c31bf3e2/vcstool/clients/git.py#L31

Tried to fix this here. The submodules now seem to get detected as git repos. Hope there would be no unintended consequences though?


