### PR TITLE
Apply leading dashes to export command output

### DIFF
--- a/vcstool/commands/export.py
+++ b/vcstool/commands/export.py
@@ -46,7 +46,7 @@ def output_export_data(result, hide_empty=False):
         return
 
     try:
-        lines = []
+        lines = ["---"]
         lines.append('  %s:' % result['path'])
         lines.append('    type: ' + result['client'].__class__.type)
         export_data = result['export_data']


### PR DESCRIPTION
Closes #273

Applying this change to the export subcommand will allow its output to pass pre-commit checks for yaml validation.