### PR TITLE
parse shell key in repo yaml and execute the specified commands

### DIFF
--- a/vcstool/clients/vcs_base.py
+++ b/vcstool/clients/vcs_base.py
@@ -6,7 +6,7 @@ from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import Request
 from urllib.request import urlopen
-
+import shlex
 
 class VcsClientBase(object):
 
@@ -20,6 +20,11 @@ class VcsClientBase(object):
             try:
                 return self.import_
             except AttributeError:
+                pass
+        if name == 'shell':
+            try:
+                return self._shell_executor
+            except:
                 pass
         return super(VcsClientBase, self).__getattribute__(name)
 
@@ -60,6 +65,12 @@ class VcsClientBase(object):
                 }
         return None
 
+    def _shell_executor(self, command: str):
+        ret = 0
+        for cmd in command.splitlines():
+            cmd = shlex.split(cmd)
+            ret += subprocess.run(cmd).returncode
+        return ret
 
 def run_command(cmd, cwd, env=None):
     if not os.path.exists(cwd):

--- a/vcstool/commands/import_.py
+++ b/vcstool/commands/import_.py
@@ -107,6 +107,8 @@ def get_repos_in_vcstool_format(repositories):
             repo['url'] = attributes['url']
             if 'version' in attributes:
                 repo['version'] = attributes['version']
+            if 'shell' in attributes:
+                repo['shell'] = attributes['shell']
         except KeyError as e:
             print(
                 ansi('yellowf') + (
@@ -173,6 +175,8 @@ def generate_jobs(repos, args):
             str(repo['version']) if 'version' in repo else None,
             recursive=args.recursive, shallow=args.shallow)
         job = {'client': client, 'command': command}
+        if 'shell' in repo:
+            job['shell'] = repo['shell']
         jobs.append(job)
     return jobs
 

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -203,6 +203,11 @@ class Worker(threading.Thread):
                 }
             result = method(job['command'])
             result['job'] = job
+            if 'shell' in job:
+                shell_executor = getattr(job['client'], 'shell')
+                retcode = shell_executor(job['shell'])
+                if retcode != 0:
+                    logger.warning(f'shell command {job["shell"]} post cloning failed')
             return result
         except Exception as e:
             exc_tb = sys.exc_info()[2]


### PR DESCRIPTION
The idea is to write small simple shell commands in the yaml manifest under each repo, to be executed after the repo is cloned during the import command when initializing a repository. It is an optional field int the yaml manifest, it doesn't have to be included, but I personally found it helpful for me, like for symlinking files inside a certain repo to the global workspace directory for example.

I would love to hear your thoughts.